### PR TITLE
Improve mobile responsiveness across the entire app

### DIFF
--- a/src/app/(main)/admin/layout.tsx
+++ b/src/app/(main)/admin/layout.tsx
@@ -29,8 +29,8 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   }
 
   return (
-    <div className="mx-auto w-full max-w-[900px] px-4 py-6">
-      <h1 className="mb-6 text-2xl font-semibold">Admin Dashboard</h1>
+    <div className="mx-auto w-full max-w-[900px] px-3 py-4 sm:px-4 sm:py-6">
+      <h1 className="mb-4 text-xl font-semibold sm:mb-6 sm:text-2xl">Admin Dashboard</h1>
       <AdminNav />
       <div className="mt-6">{children}</div>
     </div>

--- a/src/app/(main)/docs/page.tsx
+++ b/src/app/(main)/docs/page.tsx
@@ -36,7 +36,7 @@ function Endpoint({
   children?: React.ReactNode;
 }) {
   return (
-    <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+    <div className="rounded-xl border border-border bg-card p-3 space-y-3 sm:p-5">
       <div className="flex flex-wrap items-center gap-2">
         <MethodBadge method={method} />
         <code className="font-mono text-sm text-foreground">{path}</code>
@@ -59,7 +59,7 @@ function Endpoint({
 
 function CodeBlock({ children }: { children: string }) {
   return (
-    <pre className="overflow-x-auto rounded-lg bg-background p-4 font-mono text-xs leading-relaxed text-foreground">
+    <pre className="overflow-x-auto rounded-lg bg-background p-2 font-mono text-[11px] leading-relaxed text-foreground sm:p-4 sm:text-xs">
       {children}
     </pre>
   );
@@ -81,10 +81,10 @@ function SectionHeading({
 
 export default function DocsPage() {
   return (
-    <div className="mx-auto max-w-3xl space-y-10 px-4 py-8">
+    <div className="mx-auto max-w-3xl space-y-8 px-3 py-6 sm:space-y-10 sm:px-4 sm:py-8">
       {/* Header */}
       <header className="space-y-3">
-        <h1 className="text-3xl font-bold text-foreground">
+        <h1 className="text-2xl font-bold text-foreground sm:text-3xl">
           Agent API Documentation
         </h1>
         <p className="text-muted">
@@ -123,7 +123,7 @@ export default function DocsPage() {
         <p className="mb-2 text-sm font-semibold text-foreground">
           On this page
         </p>
-        <ul className="columns-2 gap-x-6 space-y-1 text-sm text-cyan">
+        <ul className="columns-1 gap-x-6 space-y-1 text-sm text-cyan sm:columns-2">
           {[
             ["#authentication", "Authentication"],
             ["#base-url", "Base URL"],

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -16,7 +16,7 @@ export default function MainLayout({
         <ToastProvider>
           <div className="mx-auto flex min-h-screen max-w-[1280px]">
             <Sidebar />
-            <main className="min-h-screen flex-1 border-r border-border max-w-[600px]">
+            <main className="min-h-screen flex-1 border-r border-border max-w-full sm:max-w-[600px] pb-16 lg:pb-0">
               {children}
             </main>
             <RightPanel />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,6 +34,11 @@ body {
   font-family: var(--font-sans), system-ui, sans-serif;
 }
 
+/* Safe area for iOS devices with home indicator */
+.safe-area-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 /* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 8px;
@@ -47,4 +52,19 @@ body {
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--muted);
+}
+
+/* Hide scrollbar for horizontal scrollable elements */
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
+/* Prevent text size adjustment on mobile orientation change */
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -16,6 +16,12 @@ const ibmPlexMono = IBM_Plex_Mono({
 export const metadata: Metadata = {
   title: "Molt",
   description: "Where humans and AI agents share the feed",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/src/components/layout/compose-modal.tsx
+++ b/src/components/layout/compose-modal.tsx
@@ -112,18 +112,20 @@ export function ComposeModal({ open, onClose }: ComposeModalProps) {
   return (
     <Modal open={open} onClose={onClose}>
       <div
-        className="flex gap-3"
+        className="flex gap-2 sm:gap-3"
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        <Avatar src={session?.user?.image} alt={session?.user?.name ?? ""} />
+        <div className="hidden sm:block">
+          <Avatar src={session?.user?.image} alt={session?.user?.name ?? ""} />
+        </div>
         <div className={`flex-1 space-y-3 ${isDragging ? "rounded-lg ring-2 ring-cyan ring-offset-2 ring-offset-card" : ""}`}>
           <TextareaAuto
             placeholder="What's happening?"
             value={content}
             onChange={(e) => setContent(e.target.value)}
-            className="min-h-[100px] text-lg"
+            className="min-h-[80px] text-base sm:min-h-[100px] sm:text-lg"
             maxLength={500}
           />
 

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -13,10 +13,10 @@ export function MobileNav() {
     : "/sign-in";
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-border bg-background lg:hidden">
+    <nav className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-border bg-background lg:hidden safe-area-bottom">
       <Link
         href="/"
-        className="flex flex-1 items-center justify-center py-3 text-muted hover:text-foreground"
+        className="flex flex-1 items-center justify-center py-4 text-muted hover:text-foreground"
       >
         <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1" />
@@ -24,7 +24,7 @@ export function MobileNav() {
       </Link>
       <Link
         href="/search"
-        className="flex flex-1 items-center justify-center py-3 text-muted hover:text-foreground"
+        className="flex flex-1 items-center justify-center py-4 text-muted hover:text-foreground"
       >
         <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -32,7 +32,7 @@ export function MobileNav() {
       </Link>
       <Link
         href="/dashboard"
-        className="flex flex-1 items-center justify-center py-3 text-muted hover:text-foreground"
+        className="flex flex-1 items-center justify-center py-4 text-muted hover:text-foreground"
       >
         <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -41,7 +41,7 @@ export function MobileNav() {
       </Link>
       <Link
         href="/governance"
-        className="flex flex-1 items-center justify-center py-3 text-muted hover:text-foreground"
+        className="flex flex-1 items-center justify-center py-4 text-muted hover:text-foreground"
       >
         <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -49,7 +49,7 @@ export function MobileNav() {
       </Link>
       <Link
         href={profileHref}
-        className="flex flex-1 items-center justify-center py-3 text-muted hover:text-foreground"
+        className="flex flex-1 items-center justify-center py-4 text-muted hover:text-foreground"
       >
         <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
@@ -58,7 +58,7 @@ export function MobileNav() {
       {session?.user?.role === "ADMIN" && (
         <Link
           href="/admin"
-          className="flex flex-1 items-center justify-center py-3 text-muted hover:text-foreground"
+          className="flex flex-1 items-center justify-center py-4 text-muted hover:text-foreground"
         >
           <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />

--- a/src/components/post/post-actions.tsx
+++ b/src/components/post/post-actions.tsx
@@ -35,7 +35,7 @@ export function PostActions({
   } = useRepost(postId, isReposted, repostCount);
 
   return (
-    <div className="mt-3 flex gap-6">
+    <div className="mt-3 flex gap-2 sm:gap-6">
       <Link
         href={`/post/${postId}`}
         className="group flex items-center gap-1.5 text-muted transition-colors hover:text-cyan"

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -41,7 +41,7 @@ export function PostCard({ post }: PostCardProps) {
         )}
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-0">
               {isAgent ? (
                 <>
                   {post.agentProfileSlug ? (
@@ -73,7 +73,7 @@ export function PostCard({ post }: PostCardProps) {
                   </Link>
                   <Link
                     href={`/${post.user.username ?? ""}`}
-                    className="truncate text-sm text-muted"
+                    className="hidden truncate text-sm text-muted min-[480px]:inline"
                   >
                     @{post.user.username}
                   </Link>

--- a/src/components/post/post-image.tsx
+++ b/src/components/post/post-image.tsx
@@ -13,7 +13,7 @@ export function PostImage({ src, alt = "Post image" }: PostImageProps) {
         alt={alt}
         width={600}
         height={512}
-        className="max-h-[512px] w-full object-cover"
+        className="max-h-[300px] w-full object-cover sm:max-h-[512px]"
         unoptimized
       />
     </div>

--- a/src/components/post/post-menu.tsx
+++ b/src/components/post/post-menu.tsx
@@ -65,7 +65,7 @@ export function PostMenu({ postId, postUserId, postType, postContent, postImageU
         </button>
 
         {open && (
-          <div className="absolute right-0 top-full z-20 mt-1 w-48 rounded-lg border border-border bg-background py-1 shadow-lg">
+          <div className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border border-border bg-background py-1 shadow-lg sm:w-48">
             <button
               onClick={(e) => {
                 e.preventDefault();

--- a/src/components/reply/reply-card.tsx
+++ b/src/components/reply/reply-card.tsx
@@ -16,7 +16,7 @@ export function ReplyCard({ reply, onReply }: ReplyCardProps) {
   const isAgent = reply.type === "AGENT" && reply.agentName;
 
   return (
-    <div className="flex gap-3 py-3">
+    <div className="flex gap-2 py-3 sm:gap-3">
       {isAgent ? (
         reply.agentProfileSlug ? (
           <Link href={`/agent/${reply.agentProfileSlug}`} className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full bg-agent-purple/20 flex items-center justify-center">
@@ -37,7 +37,7 @@ export function ReplyCard({ reply, onReply }: ReplyCardProps) {
         </Link>
       )}
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0">
           {isAgent ? (
             <>
               {reply.agentProfileSlug ? (

--- a/src/components/reply/reply-composer.tsx
+++ b/src/components/reply/reply-composer.tsx
@@ -42,7 +42,7 @@ export function ReplyComposer({
   };
 
   return (
-    <div className="flex gap-3 border-b border-border p-4">
+    <div className="flex gap-2 border-b border-border p-3 sm:gap-3 sm:p-4">
       <Avatar
         src={session.user.image}
         alt={session.user.name ?? ""}

--- a/src/components/reply/reply-thread.tsx
+++ b/src/components/reply/reply-thread.tsx
@@ -21,7 +21,7 @@ export function ReplyThread({
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
 
   return (
-    <div className={depth > 0 ? "border-l-2 border-cyan/20 pl-4" : ""}>
+    <div className={depth > 0 ? "border-l-2 border-cyan/20 pl-2 sm:pl-4" : ""}>
       {replies.map((reply) => (
         <div key={reply.id}>
           <ReplyCard
@@ -35,7 +35,7 @@ export function ReplyThread({
           />
 
           {replyingTo === reply.id && (
-            <div className="ml-11">
+            <div className="ml-6 sm:ml-11">
               <ReplyComposer
                 postId={postId}
                 parentReplyId={reply.id}

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -32,11 +32,11 @@ export function Modal({ open, onClose, children, className }: ModalProps) {
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center pt-20">
+    <div className="fixed inset-0 z-50 flex items-start justify-center px-4 pt-[10vh] sm:pt-20">
       <div className="fixed inset-0 bg-black/60" onClick={onClose} />
       <div
         className={cn(
-          "relative z-10 w-full max-w-lg rounded-xl border border-border bg-background p-6",
+          "relative z-10 w-full max-w-lg rounded-xl border border-border bg-background p-4 sm:p-6",
           className
         )}
       >

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -11,13 +11,13 @@ interface TabsProps {
 
 export function Tabs({ tabs, active, onChange, align = "center" }: TabsProps) {
   return (
-    <div className="flex border-b border-border">
+    <div className="flex overflow-x-auto border-b border-border scrollbar-none">
       {tabs.map((tab) => (
         <button
           key={tab.value}
           onClick={() => onChange(tab.value)}
           className={cn(
-            "relative px-4 py-3 text-sm font-medium transition-colors hover:bg-card-hover",
+            "relative whitespace-nowrap px-4 py-3 text-sm font-medium transition-colors hover:bg-card-hover",
             align === "center" && "flex-1",
             active === tab.value
               ? "-mb-px border-b-2 border-cyan text-foreground"


### PR DESCRIPTION
- Main layout: remove max-w-[600px] constraint on mobile, add bottom
  padding to clear fixed mobile nav
- Mobile nav: increase touch targets (py-3 -> py-4), add iOS safe area
  padding
- Modal: responsive positioning (pt-[10vh] on mobile vs pt-20 desktop),
  add horizontal padding, smaller inner padding on mobile
- Compose modal: hide avatar on small screens to maximize textarea
  width, scale text size responsively
- Post card: allow metadata line to wrap with flex-wrap, hide @username
  on very narrow screens (<480px) to prevent overflow
- Post actions: tighter gap on mobile (gap-2 vs gap-6)
- Post image: smaller max-height on mobile (300px vs 512px)
- Post menu: narrower dropdown on mobile (w-40 vs w-48)
- Reply thread: reduce nesting indentation on mobile (pl-2/ml-6 vs
  pl-4/ml-11)
- Reply card/composer: tighter gaps and padding on mobile
- Tabs: horizontal scroll with hidden scrollbar for overflow on narrow
  screens
- Docs page: single-column TOC on mobile, smaller code blocks/padding,
  responsive heading sizes
- Admin layout: responsive padding and heading size
- Root layout: add viewport-fit=cover for iOS safe areas
- Global CSS: add safe-area-bottom utility, scrollbar-none utility,
  text-size-adjust for orientation changes

https://claude.ai/code/session_01Qm4h7PZtV5kewR2fZF87v7