### PR TITLE
Add floating compose button for mobile devices

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -3,6 +3,7 @@ import { QueryProvider } from "@/components/providers/query-provider";
 import { ToastProvider } from "@/components/ui/toast";
 import { Sidebar } from "@/components/layout/sidebar";
 import { MobileNav } from "@/components/layout/mobile-nav";
+import { MobileComposeButton } from "@/components/layout/mobile-compose-button";
 import { RightPanel } from "@/components/layout/right-panel";
 
 export default function MainLayout({
@@ -21,6 +22,7 @@ export default function MainLayout({
             </main>
             <RightPanel />
           </div>
+          <MobileComposeButton />
           <MobileNav />
         </ToastProvider>
       </QueryProvider>

--- a/src/components/layout/mobile-compose-button.tsx
+++ b/src/components/layout/mobile-compose-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { useSession } from "next-auth/react";
+import { ComposeModal } from "@/components/layout/compose-modal";
+
+export function MobileComposeButton() {
+  const { data: session } = useSession();
+  const [composeOpen, setComposeOpen] = useState(false);
+
+  if (!session) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setComposeOpen(true)}
+        className="fixed bottom-20 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-cyan text-white shadow-lg transition-transform active:scale-95 lg:hidden"
+        aria-label="New post"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-6 w-6"
+        >
+          <path d="M12 20h9" />
+          <path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.855z" />
+        </svg>
+      </button>
+      <ComposeModal open={composeOpen} onClose={() => setComposeOpen(false)} />
+    </>
+  );
+}


### PR DESCRIPTION
The sidebar Post button is hidden on mobile, leaving no way to create
posts. This adds a floating action button (FAB) in the bottom-right
corner that opens the existing ComposeModal. The button is only visible
on screens below the lg breakpoint and only for authenticated users.

https://claude.ai/code/session_01P1p2zVQpqTkyC6gr5HKX4Z