### PR TITLE
Add link preview support for posts with OG metadata extraction

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,11 @@ model Post {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  linkPreviewUrl    String? @db.Text
+  linkPreviewImage  String? @db.Text
+  linkPreviewTitle  String? @db.VarChar(300)
+  linkPreviewDomain String? @db.VarChar(255)
+
   likeCount   Int @default(0)
   replyCount  Int @default(0)
   repostCount Int @default(0)

--- a/src/app/(main)/post/[postId]/page.tsx
+++ b/src/app/(main)/post/[postId]/page.tsx
@@ -7,6 +7,7 @@ import { Avatar } from "@/components/ui/avatar";
 
 import { PostContent } from "@/components/post/post-content";
 import { PostImage } from "@/components/post/post-image";
+import { LinkPreview } from "@/components/post/link-preview";
 import { PostActions } from "@/components/post/post-actions";
 import { PostMenu } from "@/components/post/post-menu";
 import { ReplyComposer } from "@/components/reply/reply-composer";
@@ -154,6 +155,15 @@ export default function PostDetailPage() {
         )}
 
         {post.imageUrl && <PostImage src={post.imageUrl} />}
+
+        {!post.imageUrl && post.linkPreviewUrl && post.linkPreviewImage && (
+          <LinkPreview
+            url={post.linkPreviewUrl}
+            image={post.linkPreviewImage}
+            title={post.linkPreviewTitle}
+            domain={post.linkPreviewDomain}
+          />
+        )}
 
         <p className="mt-3 font-mono text-xs text-muted">
           {formatTimeAgo(post.createdAt)}

--- a/src/app/api/agent/post/route.ts
+++ b/src/app/api/agent/post/route.ts
@@ -4,6 +4,7 @@ import { validateApiKey } from "@/lib/api-key";
 import { agentPostSchema } from "@/lib/validators";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { resolveAvatar } from "@/lib/utils";
+import { extractFirstUrl, fetchOgMetadata } from "@/lib/og-metadata";
 
 export async function POST(req: Request) {
   const limited = checkRateLimit(req, "agent-post", 30);
@@ -23,6 +24,9 @@ export async function POST(req: Request) {
     );
   }
 
+  const firstUrl = extractFirstUrl(parsed.data.content);
+  const ogData = firstUrl ? await fetchOgMetadata(firstUrl) : null;
+
   const post = await prisma.post.create({
     data: {
       content: parsed.data.content,
@@ -31,6 +35,12 @@ export async function POST(req: Request) {
       agentName: auth.agentProfile.name,
       userId: auth.user.id,
       agentProfileId: auth.agentProfile.id,
+      ...(ogData && {
+        linkPreviewUrl: ogData.linkPreviewUrl,
+        linkPreviewImage: ogData.linkPreviewImage,
+        linkPreviewTitle: ogData.linkPreviewTitle,
+        linkPreviewDomain: ogData.linkPreviewDomain,
+      }),
     },
     include: {
       user: {

--- a/src/app/api/posts/[postId]/route.ts
+++ b/src/app/api/posts/[postId]/route.ts
@@ -5,6 +5,7 @@ import { editPostSchema } from "@/lib/validators";
 import { deleteImage } from "@/lib/s3";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { resolveAvatar } from "@/lib/utils";
+import { extractFirstUrl, fetchOgMetadata } from "@/lib/og-metadata";
 
 export async function GET(
   _req: Request,
@@ -94,11 +95,19 @@ export async function PATCH(
     );
   }
 
+  const newContent = parsed.data.content ?? null;
+  const firstUrl = extractFirstUrl(newContent);
+  const ogData = firstUrl ? await fetchOgMetadata(firstUrl) : null;
+
   const updated = await prisma.post.update({
     where: { id: postId },
     data: {
-      content: parsed.data.content ?? null,
+      content: newContent,
       imageUrl: parsed.data.imageUrl ?? null,
+      linkPreviewUrl: ogData?.linkPreviewUrl ?? null,
+      linkPreviewImage: ogData?.linkPreviewImage ?? null,
+      linkPreviewTitle: ogData?.linkPreviewTitle ?? null,
+      linkPreviewDomain: ogData?.linkPreviewDomain ?? null,
     },
     include: {
       user: {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { createPostSchema } from "@/lib/validators";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { resolveAvatar } from "@/lib/utils";
+import { extractFirstUrl, fetchOgMetadata } from "@/lib/og-metadata";
 
 export async function POST(req: Request) {
   const session = await auth();
@@ -30,12 +31,22 @@ export async function POST(req: Request) {
     );
   }
 
+  // Fetch OG metadata for the first URL in the content (non-blocking on failure)
+  const firstUrl = extractFirstUrl(parsed.data.content);
+  const ogData = firstUrl ? await fetchOgMetadata(firstUrl) : null;
+
   const post = await prisma.post.create({
     data: {
       content: parsed.data.content,
       imageUrl: parsed.data.imageUrl,
       type: "HUMAN",
       userId: session.user.id,
+      ...(ogData && {
+        linkPreviewUrl: ogData.linkPreviewUrl,
+        linkPreviewImage: ogData.linkPreviewImage,
+        linkPreviewTitle: ogData.linkPreviewTitle,
+        linkPreviewDomain: ogData.linkPreviewDomain,
+      }),
     },
     include: {
       user: {

--- a/src/components/post/link-preview.tsx
+++ b/src/components/post/link-preview.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+interface LinkPreviewProps {
+  url: string;
+  image: string;
+  title: string | null;
+  domain: string | null;
+}
+
+export function LinkPreview({ url, image, title, domain }: LinkPreviewProps) {
+  const [imgError, setImgError] = useState(false);
+
+  if (imgError) return null;
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="mt-3 block overflow-hidden rounded-xl border border-border transition-colors hover:bg-card-hover/50"
+    >
+      <div className="relative aspect-[1.91/1] w-full bg-card">
+        <Image
+          src={image}
+          alt={title || "Link preview"}
+          fill
+          className="object-cover"
+          unoptimized
+          onError={() => setImgError(true)}
+        />
+      </div>
+      {(title || domain) && (
+        <div className="px-3 py-2">
+          {title && (
+            <p className="line-clamp-2 text-sm font-medium text-foreground">
+              {title}
+            </p>
+          )}
+          {domain && (
+            <p className="mt-0.5 text-xs text-muted">{domain}</p>
+          )}
+        </div>
+      )}
+    </a>
+  );
+}

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -5,6 +5,7 @@ import { Avatar } from "@/components/ui/avatar";
 
 import { PostContent } from "@/components/post/post-content";
 import { PostImage } from "@/components/post/post-image";
+import { LinkPreview } from "@/components/post/link-preview";
 import { PostActions } from "@/components/post/post-actions";
 import { PostMenu } from "@/components/post/post-menu";
 import { formatTimeAgo } from "@/lib/utils";
@@ -106,6 +107,15 @@ export function PostCard({ post }: PostCardProps) {
           )}
 
           {post.imageUrl && <PostImage src={post.imageUrl} />}
+
+          {!post.imageUrl && post.linkPreviewUrl && post.linkPreviewImage && (
+            <LinkPreview
+              url={post.linkPreviewUrl}
+              image={post.linkPreviewImage}
+              title={post.linkPreviewTitle}
+              domain={post.linkPreviewDomain}
+            />
+          )}
 
           <PostActions
             postId={post.id}

--- a/src/hooks/use-feed.ts
+++ b/src/hooks/use-feed.ts
@@ -9,6 +9,10 @@ export interface PostData {
   type: "HUMAN" | "AGENT";
   agentName: string | null;
   agentProfileSlug: string | null;
+  linkPreviewUrl: string | null;
+  linkPreviewImage: string | null;
+  linkPreviewTitle: string | null;
+  linkPreviewDomain: string | null;
   createdAt: string;
   updatedAt: string;
   likeCount: number;

--- a/src/lib/og-metadata.ts
+++ b/src/lib/og-metadata.ts
@@ -1,0 +1,131 @@
+const URL_REGEX = /https?:\/\/[^\s<]+/g;
+
+interface OgMetadata {
+  linkPreviewUrl: string;
+  linkPreviewImage: string | null;
+  linkPreviewTitle: string | null;
+  linkPreviewDomain: string;
+}
+
+/**
+ * Extract the first URL from post content.
+ */
+export function extractFirstUrl(content: string | null | undefined): string | null {
+  if (!content) return null;
+  const match = content.match(URL_REGEX);
+  return match ? match[0] : null;
+}
+
+/**
+ * Fetch Open Graph metadata for a URL.
+ * Returns null if the URL is unreachable or has no og:image.
+ */
+export async function fetchOgMetadata(url: string): Promise<OgMetadata | null> {
+  try {
+    const parsed = new URL(url);
+    const domain = parsed.hostname.replace(/^www\./, "");
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "MoltSocial/1.0 (link-preview bot)",
+        Accept: "text/html",
+      },
+      redirect: "follow",
+    });
+
+    clearTimeout(timeout);
+
+    if (!res.ok) return null;
+
+    const contentType = res.headers.get("content-type") ?? "";
+    if (!contentType.includes("text/html")) return null;
+
+    // Read only the first 50KB to find meta tags (avoid downloading large pages)
+    const reader = res.body?.getReader();
+    if (!reader) return null;
+
+    let html = "";
+    const decoder = new TextDecoder();
+    const maxBytes = 50_000;
+
+    while (html.length < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      html += decoder.decode(value, { stream: true });
+      // Stop early if we've passed </head>
+      if (html.includes("</head>")) break;
+    }
+    reader.cancel().catch(() => {});
+
+    const ogImage = extractMetaContent(html, "og:image");
+    const ogTitle = extractMetaContent(html, "og:title");
+    const twitterImage = extractMetaContent(html, "twitter:image");
+    const twitterTitle = extractMetaContent(html, "twitter:title");
+
+    const image = ogImage || twitterImage;
+    if (!image) return null;
+
+    // Resolve relative image URLs
+    let resolvedImage = image;
+    try {
+      resolvedImage = new URL(image, url).href;
+    } catch {
+      // Keep as-is if URL resolution fails
+    }
+
+    const title = ogTitle || twitterTitle || null;
+
+    return {
+      linkPreviewUrl: url,
+      linkPreviewImage: resolvedImage,
+      linkPreviewTitle: title ? title.slice(0, 300) : null,
+      linkPreviewDomain: domain.slice(0, 255),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a meta tag's content attribute from HTML.
+ * Handles both property="..." and name="..." patterns with content in either order.
+ */
+function extractMetaContent(html: string, property: string): string | null {
+  // Match <meta ... property="og:image" ... content="..." ...> or
+  //        <meta ... content="..." ... property="og:image" ...>
+  // Also handles name= for twitter: tags
+  const attr = property.startsWith("twitter:") ? "name" : "property";
+  const patterns = [
+    new RegExp(
+      `<meta[^>]+${attr}=["']${escapeRegex(property)}["'][^>]+content=["']([^"']+)["']`,
+      "i"
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+${attr}=["']${escapeRegex(property)}["']`,
+      "i"
+    ),
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) return decodeHtmlEntities(match[1]);
+  }
+  return null;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function decodeHtmlEntities(str: string): string {
+  return str
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}


### PR DESCRIPTION
## Summary
This PR adds automatic link preview functionality to posts. When a post contains a URL, the system now extracts Open Graph metadata (image, title, domain) and displays a rich preview card alongside the post content.

## Key Changes

- **Database Schema**: Added four new optional fields to the `Post` model:
  - `linkPreviewUrl`: The original URL
  - `linkPreviewImage`: OG image URL
  - `linkPreviewTitle`: OG title (max 300 chars)
  - `linkPreviewDomain`: Domain name (max 255 chars)

- **OG Metadata Extraction** (`src/lib/og-metadata.ts`):
  - `extractFirstUrl()`: Regex-based URL extraction from post content
  - `fetchOgMetadata()`: Fetches and parses Open Graph/Twitter Card metadata with:
    - 5-second timeout to prevent hanging
    - 50KB read limit to avoid downloading large pages
    - Early termination after `</head>` tag
    - Fallback to Twitter Card tags if OG tags unavailable
    - Relative URL resolution for images
    - HTML entity decoding

- **API Endpoints**: Updated all post creation/update endpoints to extract and store metadata:
  - `POST /api/posts` (user posts)
  - `POST /api/agent/post` (agent posts)
  - `PATCH /api/posts/[postId]` (post edits)

- **UI Components**:
  - New `LinkPreview` component: Displays preview card with image, title, and domain
  - Shows only when post has no image (prevents duplicate media)
  - Gracefully handles image load failures
  - Integrated into `PostCard` and post detail page

- **Type Updates**: Extended `PostData` interface in `use-feed.ts` with new link preview fields

## Implementation Details

- Link previews are **non-blocking**: OG metadata fetch failures don't prevent post creation
- Previews only display when both `linkPreviewUrl` and `linkPreviewImage` exist
- Image previews take precedence over link previews (no duplicate media display)
- Metadata is re-fetched on post edits to keep previews current
- User-Agent header identifies the bot for better server compatibility

https://claude.ai/code/session_016tB1ut62MFmKRk6r6qtUTt