### PR TITLE
Add share button to post actions with copy-to-clipboard

### DIFF
--- a/src/components/post/post-actions.tsx
+++ b/src/components/post/post-actions.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { formatCount } from "@/lib/utils";
 import { useLike } from "@/hooks/use-like";
@@ -33,6 +34,15 @@ export function PostActions({
     count: rCount,
     toggle: toggleRepost,
   } = useRepost(postId, isReposted, repostCount);
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = useCallback(() => {
+    const url = `${window.location.origin}/post/${postId}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [postId]);
 
   return (
     <div className="mt-3 flex gap-2 sm:gap-6">
@@ -102,6 +112,45 @@ export function PostActions({
           />
         </svg>
         <span className="text-sm">{formatCount(lCount)}</span>
+      </button>
+
+      <button
+        onClick={handleShare}
+        className={cn(
+          "group flex items-center gap-1.5 transition-colors",
+          copied ? "text-cyan" : "text-muted hover:text-cyan"
+        )}
+      >
+        {copied ? (
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        ) : (
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+            />
+          </svg>
+        )}
+        {copied && <span className="text-sm">Copied</span>}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
Added a new share button to the post actions component that allows users to copy the post URL to their clipboard with visual feedback.

## Changes
- Added `useState` and `useCallback` hooks from React for state management and memoization
- Implemented `handleShare` function that:
  - Constructs the post URL using the origin and post ID
  - Copies the URL to clipboard using the Clipboard API
  - Shows a "Copied" confirmation message for 2 seconds
- Added a new share button that:
  - Displays a share icon by default
  - Changes to a checkmark icon when the URL is copied
  - Shows "Copied" text feedback after successful copy
  - Uses cyan color on success and muted color with hover state otherwise
  - Follows the same styling pattern as other post action buttons

## Implementation Details
- The share button is placed after the like button in the action group
- Uses conditional rendering to show different icons based on the `copied` state
- The copied state automatically resets after 2 seconds using `setTimeout`
- The `handleShare` callback is memoized with `postId` as a dependency to prevent unnecessary re-renders
- Maintains consistent styling with existing post action buttons using the `cn` utility

https://claude.ai/code/session_018riKQnsknUi2jair5BZP2B