### PR TITLE
UI: AI summary in right panel tile on desktop

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,5 +1,6 @@
 import { SessionProvider } from "@/components/providers/session-provider";
 import { QueryProvider } from "@/components/providers/query-provider";
+import { AiSummaryProvider } from "@/components/providers/ai-summary-provider";
 import { ToastProvider } from "@/components/ui/toast";
 import { Sidebar } from "@/components/layout/sidebar";
 import { MobileNav } from "@/components/layout/mobile-nav";
@@ -14,7 +15,8 @@ export default function MainLayout({
   return (
     <SessionProvider>
       <QueryProvider>
-        <ToastProvider>
+        <AiSummaryProvider>
+          <ToastProvider>
           <div className="mx-auto flex min-h-screen max-w-[1280px]">
             <Sidebar />
             <main className="min-h-screen flex-1 border-r border-border max-w-full sm:max-w-[600px] pb-16 lg:pb-0">
@@ -24,7 +26,8 @@ export default function MainLayout({
           </div>
           <MobileComposeButton />
           <MobileNav />
-        </ToastProvider>
+          </ToastProvider>
+        </AiSummaryProvider>
       </QueryProvider>
     </SessionProvider>
   );

--- a/src/app/(main)/post/[postId]/page.tsx
+++ b/src/app/(main)/post/[postId]/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -15,6 +14,8 @@ import { ReplyComposer } from "@/components/reply/reply-composer";
 import { ReplyThread } from "@/components/reply/reply-thread";
 import { RelatedPostsCarousel } from "@/components/post/related-posts-carousel";
 import { PostAiPanel } from "@/components/post/post-ai-panel";
+import { useAiSummary } from "@/components/providers/ai-summary-provider";
+import { useIsRightPanelVisible } from "@/hooks/use-media-query";
 import { Spinner } from "@/components/ui/spinner";
 import { formatTimeAgo, buildReplyTree } from "@/lib/utils";
 import type { PostData } from "@/hooks/use-feed";
@@ -23,7 +24,9 @@ import type { ReplyNode } from "@/lib/utils";
 export default function PostDetailPage() {
   const { postId } = useParams<{ postId: string }>();
   const router = useRouter();
-  const [showAi, setShowAi] = useState(false);
+  const { openSummary, closeSummary, isSummaryOpenFor } = useAiSummary();
+  const isRightPanelVisible = useIsRightPanelVisible();
+  const showAi = postId ? isSummaryOpenFor(postId) : false;
 
   const { data: post, isLoading: postLoading } = useQuery<PostData>({
     queryKey: ["post", postId],
@@ -50,6 +53,12 @@ export default function PostDetailPage() {
   if (!post) {
     return <div className="p-8 text-center text-muted">Post not found</div>;
   }
+
+  const handleToggleAi = () => {
+    if (!post.content) return;
+    if (showAi) closeSummary();
+    else openSummary(post.id, post.content);
+  };
 
   const replyTree = repliesData?.replies ? buildReplyTree(repliesData.replies) : [];
 
@@ -185,16 +194,16 @@ export default function PostDetailPage() {
             repostCount={post.repostCount}
             isLiked={post.isLiked}
             isReposted={post.isReposted}
-            onToggleAi={() => setShowAi((v) => !v)}
+            onToggleAi={handleToggleAi}
             showAi={showAi}
           />
         </div>
       </article>
 
-      {showAi && post.content && (
+      {showAi && post.content && !isRightPanelVisible && (
         <PostAiPanel
           postContent={post.content}
-          onClose={() => setShowAi(false)}
+          onClose={closeSummary}
         />
       )}
 

--- a/src/components/layout/right-panel.tsx
+++ b/src/components/layout/right-panel.tsx
@@ -4,6 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 import { Avatar } from "@/components/ui/avatar";
 import { FollowButton } from "@/components/profile/follow-button";
 import { AgentFollowButton } from "@/components/profile/agent-follow-button";
+import { PostAiPanel } from "@/components/post/post-ai-panel";
+import { useAiSummary } from "@/components/providers/ai-summary-provider";
 import Link from "next/link";
 
 interface SuggestedUser {
@@ -25,6 +27,7 @@ interface SuggestedAgent {
 }
 
 export function RightPanel() {
+  const { activeSummary, closeSummary } = useAiSummary();
   const { data: suggestions } = useQuery<SuggestedUser[]>({
     queryKey: ["suggestions"],
     queryFn: () => fetch("/api/users/suggestions").then((r) => r.json()),
@@ -101,6 +104,16 @@ export function RightPanel() {
           your dashboard to let it post on your behalf.
         </p>
       </div>
+
+      {activeSummary && (
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          <PostAiPanel
+            postContent={activeSummary.postContent}
+            onClose={closeSummary}
+            embedded
+          />
+        </div>
+      )}
     </aside>
   );
 }

--- a/src/components/post/post-ai-panel.tsx
+++ b/src/components/post/post-ai-panel.tsx
@@ -10,9 +10,11 @@ import { cn } from "@/lib/utils";
 interface PostAiPanelProps {
   postContent: string;
   onClose: () => void;
+  /** When true, omit top border (e.g. when inside a right-panel tile). */
+  embedded?: boolean;
 }
 
-export function PostAiPanel({ postContent, onClose }: PostAiPanelProps) {
+export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps) {
   const { data: settings, isLoading: settingsLoading } = useLlmSettings();
   const { messages, streaming, error, sendMessage, reset } =
     useLlmChat(postContent);
@@ -49,7 +51,7 @@ export function PostAiPanel({ postContent, onClose }: PostAiPanelProps) {
   // Not configured state
   if (!settingsLoading && !settings?.configured) {
     return (
-      <div className="border-t border-border bg-card/50 px-4 py-4">
+      <div className={cn(!embedded && "border-t border-border", "bg-card/50 px-4 py-4")}>
         <div className="flex items-start justify-between">
           <div>
             <p className="text-sm font-medium">Set up AI</p>
@@ -111,7 +113,7 @@ export function PostAiPanel({ postContent, onClose }: PostAiPanelProps) {
   }
 
   return (
-    <div className="border-t border-border bg-card/50">
+    <div className={cn(!embedded && "border-t border-border", "bg-card/50")}>
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-2">
         <div className="flex items-center gap-2">

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -11,6 +11,8 @@ import { PostActions } from "@/components/post/post-actions";
 import { PostMenu } from "@/components/post/post-menu";
 import { RelatedPostsCarousel } from "@/components/post/related-posts-carousel";
 import { PostAiPanel } from "@/components/post/post-ai-panel";
+import { useAiSummary } from "@/components/providers/ai-summary-provider";
+import { useIsRightPanelVisible } from "@/hooks/use-media-query";
 import { formatTimeAgo } from "@/lib/utils";
 import type { PostData } from "@/hooks/use-feed";
 
@@ -20,8 +22,15 @@ interface PostCardProps {
 
 export function PostCard({ post }: PostCardProps) {
   const [showRelated, setShowRelated] = useState(false);
-  const [showAi, setShowAi] = useState(false);
+  const { openSummary, closeSummary, isSummaryOpenFor } = useAiSummary();
+  const isRightPanelVisible = useIsRightPanelVisible();
+  const showAi = isSummaryOpenFor(post.id);
   const isAgent = post.type === "AGENT" && post.agentName;
+
+  const handleToggleAi = () => {
+    if (showAi) closeSummary();
+    else if (post.content) openSummary(post.id, post.content);
+  };
 
   return (
     <article className="border-b border-border px-4 py-3 transition-colors hover:bg-card-hover/50">
@@ -131,16 +140,16 @@ export function PostCard({ post }: PostCardProps) {
             isReposted={post.isReposted}
             onToggleRelated={() => setShowRelated((v) => !v)}
             showRelated={showRelated}
-            onToggleAi={() => setShowAi((v) => !v)}
+            onToggleAi={handleToggleAi}
             showAi={showAi}
           />
         </div>
       </div>
       <RelatedPostsCarousel postId={post.id} enabled={showRelated} />
-      {showAi && post.content && (
+      {showAi && post.content && !isRightPanelVisible && (
         <PostAiPanel
           postContent={post.content}
-          onClose={() => setShowAi(false)}
+          onClose={closeSummary}
         />
       )}
     </article>

--- a/src/components/providers/ai-summary-provider.tsx
+++ b/src/components/providers/ai-summary-provider.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+export interface ActiveSummary {
+  postId: string;
+  postContent: string;
+}
+
+interface AiSummaryContextValue {
+  activeSummary: ActiveSummary | null;
+  openSummary: (postId: string, postContent: string) => void;
+  closeSummary: () => void;
+  isSummaryOpenFor: (postId: string) => boolean;
+}
+
+const AiSummaryContext = createContext<AiSummaryContextValue | null>(null);
+
+export function AiSummaryProvider({ children }: { children: ReactNode }) {
+  const [activeSummary, setActiveSummary] = useState<ActiveSummary | null>(
+    null
+  );
+
+  const openSummary = useCallback((postId: string, postContent: string) => {
+    setActiveSummary((prev) => {
+      if (prev?.postId === postId) return null;
+      return { postId, postContent };
+    });
+  }, []);
+
+  const closeSummary = useCallback(() => setActiveSummary(null), []);
+
+  const isSummaryOpenFor = useCallback(
+    (postId: string) => activeSummary?.postId === postId,
+    [activeSummary?.postId]
+  );
+
+  return (
+    <AiSummaryContext.Provider
+      value={{
+        activeSummary,
+        openSummary,
+        closeSummary,
+        isSummaryOpenFor,
+      }}
+    >
+      {children}
+    </AiSummaryContext.Provider>
+  );
+}
+
+export function useAiSummary(): AiSummaryContextValue {
+  const ctx = useContext(AiSummaryContext);
+  if (!ctx) {
+    throw new Error("useAiSummary must be used within AiSummaryProvider");
+  }
+  return ctx;
+}

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const m = window.matchMedia(query);
+    setMatches(m.matches);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    m.addEventListener("change", handler);
+    return () => m.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}
+
+/** True when viewport is xl (1280px) or wider — right panel is visible. */
+export function useIsRightPanelVisible(): boolean {
+  return useMediaQuery("(min-width: 1280px)");
+}


### PR DESCRIPTION
On desktop, the AI summary now opens in a new tile in the right sidebar under "About Molt" instead of below the post. On smaller viewports it still opens below the post.

**Description**
- Add AiSummaryProvider context so the right panel can show the active post's summary
- Add an AI Summary tile under "About Molt" in the right panel when the user opens a summary (desktop only)
- On viewport xl and up, summary shows only in the right panel; below xl it still shows under the post

Made with [Cursor](https://cursor.com)