### PR TITLE
AI summary: Keep main feed fixed while summary streams in right panel

### DIFF
--- a/src/components/post/post-ai-panel.tsx
+++ b/src/components/post/post-ai-panel.tsx
@@ -20,7 +20,7 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
     useLlmChat(postContent);
   const [input, setInput] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
   const initialized = useRef(false);
 
   // Auto-summarize on first mount when configured
@@ -31,9 +31,10 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
     }
   }, [settings?.configured, messages.length, sendMessage]);
 
-  // Scroll to bottom on new messages
+  // Scroll messages area to bottom on new content (only the panel's scroll container, not the page)
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    const el = messagesContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
   }, [messages]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -189,7 +190,10 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
       </div>
 
       {/* Messages area */}
-      <div className="max-h-80 overflow-y-auto px-4 py-3">
+      <div
+        ref={messagesContainerRef}
+        className="max-h-80 overflow-y-auto px-4 py-3"
+      >
         {settingsLoading && (
           <div className="flex items-center gap-2 text-sm text-muted">
             <div className="h-4 w-4 animate-spin rounded-full border-2 border-cyan border-t-transparent" />
@@ -228,8 +232,6 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
             {error}
           </p>
         )}
-
-        <div ref={messagesEndRef} />
       </div>
 
       {/* Input for follow-up questions */}


### PR DESCRIPTION
**TL;DR:** When the AI summary was streaming in the right panel, the main feed scrolled because we used `scrollIntoView`, which scrolls the whole page. We now scroll only the panel’s messages container so the feed stays fixed.

**Description**
- Replaced `scrollIntoView()` on the messages end with setting `scrollTop = scrollHeight` on the messages container ref so only the right-panel messages area scrolls.
- Removed the sentinel div that was only used for scroll-into-view; the container ref is attached to the existing `max-h-80 overflow-y-auto` div.
