### PR TITLE
Settings: Move AI summary configuration to dashboard

### DIFF
--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import { ApiKeyCard } from "@/components/dashboard/api-key-card";
 import { AgentProfilesCard } from "@/components/dashboard/agent-profiles-card";
 import { ApiKeyDocs } from "@/components/dashboard/api-key-docs";
+import { LlmSettingsCard } from "@/components/dashboard/llm-settings-card";
 
 export default function DashboardPage() {
   const { data: session, status } = useSession();
@@ -25,6 +26,7 @@ export default function DashboardPage() {
         <h1 className="text-lg font-semibold">Agent Dashboard</h1>
       </div>
       <div className="space-y-4 p-4">
+        <LlmSettingsCard />
         <AgentProfilesCard />
         <ApiKeyCard />
         <ApiKeyDocs />

--- a/src/components/dashboard/llm-settings-card.tsx
+++ b/src/components/dashboard/llm-settings-card.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { LlmSettingsForm } from "@/components/dashboard/llm-settings-form";
+
+export function LlmSettingsCard() {
+  return (
+    <div
+      id="ai-settings"
+      className="rounded-xl border border-border bg-card p-6 space-y-4"
+    >
+      <div>
+        <h2 className="text-lg font-semibold">AI Summary</h2>
+        <p className="text-sm text-muted">
+          Configure your LLM provider to summarize and discuss posts. Your API
+          key is encrypted and stored securely.
+        </p>
+      </div>
+      <LlmSettingsForm />
+    </div>
+  );
+}

--- a/src/components/dashboard/llm-settings-form.tsx
+++ b/src/components/dashboard/llm-settings-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import {
   useLlmSettings,
@@ -14,12 +13,7 @@ import {
   getDefaultModel,
 } from "@/lib/llm-providers";
 
-interface LlmSettingsModalProps {
-  open: boolean;
-  onClose: () => void;
-}
-
-export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
+export function LlmSettingsForm() {
   const { data: settings } = useLlmSettings();
   const saveMutation = useSaveLlmSettings();
   const deleteMutation = useDeleteLlmSettings();
@@ -29,17 +23,15 @@ export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
   const [apiKey, setApiKey] = useState("");
   const [error, setError] = useState("");
 
-  // Populate from saved settings when modal opens
   useEffect(() => {
-    if (open && settings) {
+    if (settings) {
       setProvider(settings.provider ?? "");
       setModel(settings.model ?? "");
       setApiKey("");
       setError("");
     }
-  }, [open, settings]);
+  }, [settings]);
 
-  // When provider changes, reset model to first available
   const handleProviderChange = (newProvider: string) => {
     setProvider(newProvider);
     setModel(getDefaultModel(newProvider));
@@ -56,7 +48,6 @@ export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
     try {
       await saveMutation.mutateAsync({ provider, model, apiKey });
       setApiKey("");
-      onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
     }
@@ -68,20 +59,13 @@ export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
       setProvider("");
       setModel("");
       setApiKey("");
-      onClose();
     } catch {
       setError("Failed to remove settings");
     }
   };
 
   return (
-    <Modal open={open} onClose={onClose}>
-      <h2 className="mb-1 text-lg font-semibold">AI Settings</h2>
-      <p className="mb-4 text-sm text-muted">
-        Configure your LLM provider to summarize and discuss posts. Your API key
-        is encrypted and stored securely.
-      </p>
-
+    <>
       {error && (
         <p className="mb-3 rounded-lg bg-heart-red/10 px-3 py-2 text-sm text-heart-red">
           {error}
@@ -89,7 +73,6 @@ export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
       )}
 
       <div className="space-y-4">
-        {/* Provider select */}
         <div>
           <label className="mb-1 block text-sm font-medium">Provider</label>
           <select
@@ -106,7 +89,6 @@ export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
           </select>
         </div>
 
-        {/* Model select */}
         {selectedProvider && (
           <div>
             <label className="mb-1 block text-sm font-medium">Model</label>
@@ -124,7 +106,6 @@ export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
           </div>
         )}
 
-        {/* API Key */}
         {selectedProvider && (
           <div>
             <label className="mb-1 block text-sm font-medium">API Key</label>
@@ -159,9 +140,6 @@ export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
           )}
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={onClose}>
-            Cancel
-          </Button>
           <Button
             size="sm"
             onClick={handleSave}
@@ -176,6 +154,6 @@ export function LlmSettingsModal({ open, onClose }: LlmSettingsModalProps) {
           </Button>
         </div>
       </div>
-    </Modal>
+    </>
   );
 }

--- a/src/components/post/post-ai-panel.tsx
+++ b/src/components/post/post-ai-panel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import Link from "next/link";
 import { useLlmChat } from "@/hooks/use-llm-chat";
 import { useLlmSettings } from "@/hooks/use-llm-settings";
-import { LlmSettingsModal } from "@/components/post/llm-settings-modal";
 import { getProvider } from "@/lib/llm-providers";
 import { cn } from "@/lib/utils";
 
@@ -19,7 +19,6 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
   const { messages, streaming, error, sendMessage, reset } =
     useLlmChat(postContent);
   const [input, setInput] = useState("");
-  const [settingsOpen, setSettingsOpen] = useState(false);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const initialized = useRef(false);
 
@@ -80,8 +79,8 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
             </svg>
           </button>
         </div>
-        <button
-          onClick={() => setSettingsOpen(true)}
+        <Link
+          href="/dashboard#ai-settings"
           className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-cyan px-3 py-1.5 text-xs font-medium text-black transition-colors hover:bg-cyan/90"
         >
           <svg
@@ -103,12 +102,8 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
               d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
             />
           </svg>
-          Configure AI Provider
-        </button>
-        <LlmSettingsModal
-          open={settingsOpen}
-          onClose={() => setSettingsOpen(false)}
-        />
+          Configure in Settings
+        </Link>
       </div>
     );
   }
@@ -139,8 +134,8 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
           )}
         </div>
         <div className="flex items-center gap-1">
-          <button
-            onClick={() => setSettingsOpen(true)}
+          <Link
+            href="/dashboard#ai-settings"
             className="rounded p-1 text-muted transition-colors hover:bg-card-hover hover:text-foreground"
             title="AI Settings"
           >
@@ -163,7 +158,7 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
                 d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
               />
             </svg>
-          </button>
+          </Link>
           <button
             onClick={() => {
               reset();
@@ -274,11 +269,6 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
           </button>
         </form>
       )}
-
-      <LlmSettingsModal
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-      />
     </div>
   );
 }


### PR DESCRIPTION
**TLDR:** AI Summary (LLM provider/model/API key) is now configured only on the Settings (dashboard) page; the post AI panel links to Settings instead of opening a modal.

**Description**
- Add an "AI Summary" card on the dashboard (`/dashboard#ai-settings`) with the existing provider/model/API key form (extracted into `LlmSettingsForm` + `LlmSettingsCard`).
- Update the post AI panel: when not configured, show "Configure in Settings" linking to dashboard; when configured, the gear icon links to dashboard instead of opening a modal.
- Remove `LlmSettingsModal`; configuration lives only on the settings page.

Made with [Cursor](https://cursor.com)