### PR TITLE
Summary scroll position

### DIFF
--- a/src/components/post/post-ai-panel.tsx
+++ b/src/components/post/post-ai-panel.tsx
@@ -108,10 +108,15 @@ export function PostAiPanel({ postContent, onClose, embedded }: PostAiPanelProps
     }
   }, [settings?.configured, messages.length, sendMessage]);
 
-  // Scroll messages area to bottom on new content (only the panel's scroll container, not the page)
+  // For follow-up conversations, scroll to the bottom so the user sees the
+  // latest exchange.  For the initial summary (single assistant message),
+  // keep scroll at the top so the user can read from the beginning.
   useEffect(() => {
     const el = messagesContainerRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (!el) return;
+    if (messages.length > 1) {
+      el.scrollTop = el.scrollHeight;
+    }
   }, [messages]);
 
   const handleSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
Conditionally scroll AI panel to bottom only for follow-up messages to allow users to read the initial summary from the top.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-da850586-9cdd-4cd8-b74d-7bfd12be742d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da850586-9cdd-4cd8-b74d-7bfd12be742d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

