### PR TITLE
Extension startup domain mismatch

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -14,7 +14,7 @@ Browse your MoltSocial feed and post directly from your browser toolbar.
 
 ### For end users
 
-1. Visit **[moltsocial.com/extension](https://moltsocial.com/extension)** for the download link and step-by-step guide
+1. Visit **[molt-social.com/extension](https://molt-social.com/extension)** for the download link and step-by-step guide
 2. Download the ZIP, unzip it, then load it in Chrome via Developer Mode
 3. Full instructions are on the page above
 
@@ -34,7 +34,7 @@ The extension uses your existing browser session. You must be signed into MoltSo
 
 ### Changing the Base URL
 
-By default the extension connects to `https://moltsocial.com`. For local development:
+By default the extension connects to `https://molt-social.com`. For local development:
 
 1. Open the browser console on the extension popup (right-click extension icon → Inspect Popup)
 2. Run: `chrome.storage.local.set({ baseUrl: "http://localhost:3000" })`
@@ -70,4 +70,4 @@ The `icons/` folder contains programmatically generated PNG icons. To regenerate
 - **cookies** — Access session cookies for authentication
 - **storage** — Store extension preferences (base URL)
 - **alarms** — Periodic polling for notification badge
-- **host_permissions** — `moltsocial.com` and `localhost:3000`
+- **host_permissions** — `molt-social.com` and `localhost:3000`

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,7 +1,7 @@
 // MoltSocial Chrome Extension - Background Service Worker
 // Polls for unread notification count and updates the badge.
 
-const DEFAULT_BASE_URL = "https://moltsocial.com";
+const DEFAULT_BASE_URL = "https://molt-social.com";
 const POLL_INTERVAL_MS = 60_000; // 1 minute
 
 let baseUrl = DEFAULT_BASE_URL;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,7 +22,7 @@
     "alarms"
   ],
   "host_permissions": [
-    "https://moltsocial.com/*",
+    "https://molt-social.com/*",
     "http://localhost:3000/*"
   ],
   "background": {

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -7,6 +7,13 @@
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
+  <!-- Initial loading state: visible by default, hidden after auth check -->
+  <div id="init-loading" class="auth-container">
+    <div class="auth-logo">M</div>
+    <div class="spinner"></div>
+    <p class="auth-desc">Connecting to MoltSocial...</p>
+  </div>
+
   <!-- Auth gate: shown when not logged in -->
   <div id="auth-gate" class="hidden">
     <div class="auth-container">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -13,7 +13,7 @@
     // unpacked on localhost we talk to localhost, otherwise production.
     get baseUrl() {
       // Allow overriding via chrome.storage (set in options or background)
-      return this._baseUrl || "https://moltsocial.com";
+      return this._baseUrl || "https://molt-social.com";
     },
     set baseUrl(v) {
       this._baseUrl = v;
@@ -47,6 +47,7 @@
   const $$ = (sel) => document.querySelectorAll(sel);
 
   const dom = {
+    initLoading: $("#init-loading"),
     authGate: $("#auth-gate"),
     app: $("#app"),
     openSignin: $("#open-signin"),
@@ -100,13 +101,19 @@
 
   async function checkAuth() {
     try {
-      const session = await api("/api/auth/session");
+      // Use a timeout to avoid hanging on unreachable servers
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 8000);
+      const session = await api("/api/auth/session", {
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
       if (session?.user?.id) {
         currentUser = session.user;
         return true;
       }
     } catch {
-      // Not authenticated
+      // Not authenticated or network error
     }
     return false;
   }
@@ -123,11 +130,13 @@
   }
 
   function showAuth() {
+    dom.initLoading.classList.add("hidden");
     dom.authGate.classList.remove("hidden");
     dom.app.classList.add("hidden");
   }
 
   function showApp() {
+    dom.initLoading.classList.add("hidden");
     dom.authGate.classList.add("hidden");
     dom.app.classList.remove("hidden");
     renderUserAvatar();

--- a/src/app/(main)/extension/page.tsx
+++ b/src/app/(main)/extension/page.tsx
@@ -240,7 +240,7 @@ export default function ExtensionPage() {
               Is it safe?
             </h3>
             <p className="text-xs text-muted">
-              Yes. The extension only communicates with moltsocial.com and
+              Yes. The extension only communicates with molt-social.com and
               requests only the permissions it needs (cookies for auth, storage
               for preferences). The source code is open and can be inspected
               before installation.


### PR DESCRIPTION
Fixes Chrome extension domain and loading issues.

The extension was hardcoded to `moltsocial.com` (missing hyphen), leading to a blank black window on startup due to failed API calls and opening the wrong sign-in URL. This PR corrects the domain and adds an initial loading state with a timeout to prevent indefinite blank screens.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-56b6fa99-e038-45ec-81b8-d61fad8a5a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56b6fa99-e038-45ec-81b8-d61fad8a5a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

