### PR TITLE
Chrome extension domain

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -4,17 +4,35 @@
 const DEFAULT_BASE_URL = "https://molt-social.com";
 const POLL_INTERVAL_MS = 60_000; // 1 minute
 
+const VALID_BASE_URLS = [
+  "https://molt-social.com",
+  "http://localhost:3000",
+];
+function isValidBaseUrl(url) {
+  const u = url?.replace(/\/$/, "");
+  return VALID_BASE_URLS.some((valid) => valid === u);
+}
+
 let baseUrl = DEFAULT_BASE_URL;
 
-// Load saved base URL
+// Load saved base URL (reject old/wrong domains like moltsocial.com)
 chrome.storage?.local?.get("baseUrl", (result) => {
-  if (result?.baseUrl) baseUrl = result.baseUrl;
+  if (result?.baseUrl && isValidBaseUrl(result.baseUrl)) {
+    baseUrl = result.baseUrl.replace(/\/$/, "");
+  } else if (result?.baseUrl) {
+    baseUrl = DEFAULT_BASE_URL;
+    chrome.storage.local.set({ baseUrl: DEFAULT_BASE_URL });
+  }
 });
 
 // Listen for base URL changes
 chrome.storage?.onChanged?.addListener((changes) => {
   if (changes.baseUrl?.newValue) {
-    baseUrl = changes.baseUrl.newValue;
+    if (isValidBaseUrl(changes.baseUrl.newValue)) {
+      baseUrl = changes.baseUrl.newValue.replace(/\/$/, "");
+    } else {
+      baseUrl = DEFAULT_BASE_URL;
+    }
   }
 });
 
@@ -68,8 +86,14 @@ chrome.runtime?.onMessage?.addListener((msg) => {
     updateBadge();
   }
   if (msg.type === "set-base-url" && msg.baseUrl) {
-    baseUrl = msg.baseUrl;
-    chrome.storage.local.set({ baseUrl: msg.baseUrl });
+    const url = msg.baseUrl.replace(/\/$/, "");
+    if (isValidBaseUrl(url)) {
+      baseUrl = url;
+      chrome.storage.local.set({ baseUrl: url });
+    } else {
+      baseUrl = DEFAULT_BASE_URL;
+      chrome.storage.local.set({ baseUrl: DEFAULT_BASE_URL });
+    }
     updateBadge();
   }
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -22,10 +22,24 @@
     feedPageSize: 20,
   };
 
-  // Try to load saved base URL
+  // Try to load saved base URL (reject old/wrong domains)
+  const VALID_BASE_URLS = [
+    "https://molt-social.com",
+    "http://localhost:3000",
+  ];
+  function isValidBaseUrl(url) {
+    const u = url?.replace(/\/$/, "");
+    return VALID_BASE_URLS.some((valid) => valid === u);
+  }
   if (chrome?.storage?.local) {
     chrome.storage.local.get("baseUrl", (result) => {
-      if (result.baseUrl) CONFIG.baseUrl = result.baseUrl;
+      if (result.baseUrl && isValidBaseUrl(result.baseUrl)) {
+        CONFIG.baseUrl = result.baseUrl.replace(/\/$/, "");
+      } else if (result.baseUrl) {
+        // Stale/wrong domain (e.g. moltsocial.com) — reset to production
+        CONFIG.baseUrl = "https://molt-social.com";
+        chrome.storage.local.set({ baseUrl: "https://molt-social.com" });
+      }
     });
   }
 


### PR DESCRIPTION
Add `baseUrl` validation to the Chrome extension to correct old/invalid stored domains.

The extension was using `baseUrl` from `chrome.storage.local` uncritically. This caused the extension to open the wrong domain (e.g., `moltsocial.com`) for users who had an outdated or invalid `baseUrl` previously stored. This PR ensures that only valid domains (`https://molt-social.com` or `http://localhost:3000`) are accepted, resetting any invalid stored URLs to `https://molt-social.com`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b1e9b233-56b7-418c-bcf9-51ad8bc15659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1e9b233-56b7-418c-bcf9-51ad8bc15659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

