### PR TITLE
Chrome extension domain

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -15,10 +15,17 @@ function isValidBaseUrl(url) {
 
 let baseUrl = DEFAULT_BASE_URL;
 
+// Legacy/wrong domains to migrate away from (e.g. moltsocial.com → molt-social.com)
+const LEGACY_BASE_URLS = ["https://moltsocial.com", "http://moltsocial.com"];
+
 // Load saved base URL (reject old/wrong domains like moltsocial.com)
 chrome.storage?.local?.get("baseUrl", (result) => {
-  if (result?.baseUrl && isValidBaseUrl(result.baseUrl)) {
-    baseUrl = result.baseUrl.replace(/\/$/, "");
+  const url = result?.baseUrl?.replace(/\/$/, "");
+  if (url && isValidBaseUrl(url)) {
+    baseUrl = url;
+  } else if (url && LEGACY_BASE_URLS.includes(url)) {
+    baseUrl = DEFAULT_BASE_URL;
+    chrome.storage.local.set({ baseUrl: DEFAULT_BASE_URL });
   } else if (result?.baseUrl) {
     baseUrl = DEFAULT_BASE_URL;
     chrome.storage.local.set({ baseUrl: DEFAULT_BASE_URL });
@@ -78,7 +85,16 @@ chrome.alarms?.onAlarm?.addListener((alarm) => {
 
 // Also update on startup and when extension is installed
 chrome.runtime?.onStartup?.addListener(updateBadge);
-chrome.runtime?.onInstalled?.addListener(updateBadge);
+chrome.runtime?.onInstalled?.addListener(() => {
+  // Migrate away from legacy moltsocial.com domain on install/update
+  chrome.storage?.local?.get("baseUrl", (result) => {
+    const url = result?.baseUrl?.replace(/\/$/, "");
+    if (url && !isValidBaseUrl(url)) {
+      chrome.storage.local.set({ baseUrl: DEFAULT_BASE_URL });
+    }
+  });
+  updateBadge();
+});
 
 // Update badge when popup opens (message from popup)
 chrome.runtime?.onMessage?.addListener((msg) => {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -22,21 +22,26 @@
     feedPageSize: 20,
   };
 
-  // Try to load saved base URL (reject old/wrong domains)
+  // Try to load saved base URL (reject old/wrong domains like moltsocial.com)
   const VALID_BASE_URLS = [
     "https://molt-social.com",
     "http://localhost:3000",
   ];
+  const LEGACY_BASE_URLS = ["https://moltsocial.com", "http://moltsocial.com"];
   function isValidBaseUrl(url) {
     const u = url?.replace(/\/$/, "");
     return VALID_BASE_URLS.some((valid) => valid === u);
   }
   if (chrome?.storage?.local) {
     chrome.storage.local.get("baseUrl", (result) => {
-      if (result.baseUrl && isValidBaseUrl(result.baseUrl)) {
-        CONFIG.baseUrl = result.baseUrl.replace(/\/$/, "");
-      } else if (result.baseUrl) {
-        // Stale/wrong domain (e.g. moltsocial.com) — reset to production
+      const url = result?.baseUrl?.replace(/\/$/, "");
+      if (url && isValidBaseUrl(url)) {
+        CONFIG.baseUrl = url;
+      } else if (url && LEGACY_BASE_URLS.includes(url)) {
+        // Legacy wrong domain (moltsocial.com) — reset to molt-social.com
+        CONFIG.baseUrl = "https://molt-social.com";
+        chrome.storage.local.set({ baseUrl: "https://molt-social.com" });
+      } else if (result?.baseUrl) {
         CONFIG.baseUrl = "https://molt-social.com";
         chrome.storage.local.set({ baseUrl: "https://molt-social.com" });
       }


### PR DESCRIPTION
Fixes Chrome extension opening `moltsocial.com` by migrating stale `baseUrl` values to `molt-social.com`.

The extension's code already used `molt-social.com`, but users with older installations might have `moltsocial.com` cached in `chrome.storage.local`, leading to the wrong URL being opened. This PR adds explicit migration logic to ensure the correct domain is used for all users, including those updating from older versions.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-59583754-d2be-439c-ab0b-2f851192f32b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-59583754-d2be-439c-ab0b-2f851192f32b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

