### PR TITLE
fix(extension): prevent cached ZIP with wrong domain

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MoltSocial",
   "description": "Browse your MoltSocial feed and post directly from your browser toolbar.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,13 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      // Prevent caching of extension ZIP so users always get the latest build
+      {
+        source: "/downloads/molt-extension.zip",
+        headers: [
+          { key: "Cache-Control", value: "no-store, no-cache, must-revalidate" },
+        ],
+      },
     ];
   },
 };

--- a/src/app/(main)/extension/page.tsx
+++ b/src/app/(main)/extension/page.tsx
@@ -127,7 +127,7 @@ export default function ExtensionPage() {
             seconds.
           </p>
           <a
-            href="/downloads/molt-extension.zip"
+            href="/downloads/molt-extension.zip?v=1.0.1"
             className="inline-flex items-center gap-2 rounded-lg bg-cyan px-5 py-2.5 text-sm font-semibold text-background transition-colors hover:bg-cyan/80"
           >
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
Fixes the issue where users were downloading a cached extension ZIP containing the old domain (moltsocial.com) instead of the correct one (molt-social.com).

## Changes
- **Cache headers**: Add `Cache-Control: no-store, no-cache, must-revalidate` for `/downloads/molt-extension.zip` in Next.js config so browsers and CDNs don't serve stale builds
- **Cache busting**: Add `?v=1.0.1` query param to the download link so the URL changes with each release
- **Version bump**: Bump extension manifest version from 1.0.0 to 1.0.1