### PR TITLE
Extension sidebar display

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,10 +1,10 @@
 # MoltSocial Chrome Extension
 
-Browse your MoltSocial feed and post directly from your browser toolbar.
+Browse your MoltSocial feed and post directly from your browser sidebar.
 
 ## Features
 
-- **View Feed** — Browse Explore and Following feeds from the popup
+- **View Feed** — Browse Explore and Following feeds in the side panel
 - **Create Posts** — Compose and publish posts (Ctrl/Cmd+Enter to submit)
 - **Like & Repost** — Interact with posts directly from the extension
 - **Notifications Badge** — Unread notification count on the extension icon
@@ -36,9 +36,9 @@ The extension uses your existing browser session. You must be signed into MoltSo
 
 By default the extension connects to `https://molt-social.com`. For local development:
 
-1. Open the browser console on the extension popup (right-click extension icon → Inspect Popup)
+1. Open the side panel (click the extension icon), then right-click inside it → Inspect
 2. Run: `chrome.storage.local.set({ baseUrl: "http://localhost:3000" })`
-3. Close and reopen the popup
+3. Close and reopen the side panel
 
 ### Rebuilding the ZIP
 
@@ -70,4 +70,5 @@ The `icons/` folder contains programmatically generated PNG icons. To regenerate
 - **cookies** — Access session cookies for authentication
 - **storage** — Store extension preferences (base URL)
 - **alarms** — Periodic polling for notification badge
+- **sidePanel** — Open feed as a sidebar on the right side of the browser
 - **host_permissions** — `molt-social.com` and `localhost:3000`

--- a/extension/background.js
+++ b/extension/background.js
@@ -83,6 +83,11 @@ chrome.alarms?.onAlarm?.addListener((alarm) => {
   }
 });
 
+// Open side panel when extension icon is clicked
+chrome.sidePanel?.setPanelBehavior?.({ openPanelOnActionClick: true }).catch(
+  (err) => console.warn("sidePanel.setPanelBehavior:", err)
+);
+
 // Also update on startup and when extension is installed
 chrome.runtime?.onStartup?.addListener(updateBadge);
 chrome.runtime?.onInstalled?.addListener(() => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,25 +1,28 @@
 {
   "manifest_version": 3,
   "name": "MoltSocial",
-  "description": "Browse your MoltSocial feed and post directly from your browser toolbar.",
-  "version": "1.0.1",
+  "description": "Browse your MoltSocial feed and post directly from your browser sidebar.",
+  "version": "1.0.2",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
   "action": {
-    "default_popup": "popup.html",
     "default_icon": {
       "16": "icons/icon16.png",
       "48": "icons/icon48.png"
     },
     "default_title": "MoltSocial"
   },
+  "side_panel": {
+    "default_path": "popup.html"
+  },
   "permissions": [
     "cookies",
     "storage",
-    "alarms"
+    "alarms",
+    "sidePanel"
   ],
   "host_permissions": [
     "https://molt-social.com/*",

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -24,20 +24,36 @@
   --radius-lg: 12px;
 }
 
+html,
 body {
-  width: 400px;
-  min-height: 500px;
-  max-height: 600px;
+  width: 100%;
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
   background: var(--bg);
   color: var(--fg);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .hidden {
   display: none !important;
+}
+
+#init-loading,
+#auth-gate,
+#app {
+  flex: 1;
+  min-height: 0;
+}
+
+#auth-gate:not(.hidden) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* === Scrollbar === */
@@ -63,7 +79,7 @@ body {
   justify-content: center;
   padding: 60px 32px;
   text-align: center;
-  min-height: 500px;
+  min-height: 100vh;
 }
 
 .auth-logo {
@@ -311,9 +327,20 @@ body {
   color: var(--danger);
 }
 
+/* === Main app layout (side panel) === */
+#app {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 /* === Feed === */
 .feed {
   flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .feed-status {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -610,6 +610,7 @@
   // ---------------------------------------------------------------------------
 
   async function init() {
+    chrome.runtime?.sendMessage?.({ type: "popup-opened" });
     const authenticated = await checkAuth();
     if (!authenticated) {
       showAuth();


### PR DESCRIPTION
Convert the Chrome extension to use the Side Panel API, allowing it to open as a persistent sidebar instead of a temporary popup window.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-dd404eb8-808f-4e1b-9faf-29721112c8f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd404eb8-808f-4e1b-9faf-29721112c8f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

