### PR TITLE
Chrome extension stream scrolling

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -24,10 +24,16 @@
   --radius-lg: 12px;
 }
 
-html,
+/* Use explicit height for Chrome side panel—100vh can use browser viewport, not panel */
+html {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   width: 100%;
-  min-height: 100vh;
+  height: 100%;
+  min-height: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
@@ -79,7 +85,8 @@ body {
   justify-content: center;
   padding: 60px 32px;
   text-align: center;
-  min-height: 100vh;
+  min-height: 0;
+  flex: 1;
 }
 
 .auth-logo {


### PR DESCRIPTION
Fixes scrolling in the Chrome extension side panel by adjusting CSS height properties.

In Chrome's side panel, `min-height: 100vh` was incorrectly using the main browser viewport instead of the panel's, preventing the flex layout from establishing a bounded height for the scrollable feed.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-02822bda-f4b1-49da-a070-f51c27000a52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02822bda-f4b1-49da-a070-f51c27000a52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

