### PR TITLE
Rename remaining nexus-social reference to molt-social

### DIFF
--- a/src/app/(main)/extension/page.tsx
+++ b/src/app/(main)/extension/page.tsx
@@ -277,7 +277,7 @@ export default function ExtensionPage() {
         <p>
           Having issues?{" "}
           <a
-            href="https://github.com/aleibovici/nexus-social/issues"
+            href="https://github.com/aleibovici/molt-social/issues"
             target="_blank"
             rel="noopener noreferrer"
             className="text-cyan hover:underline"


### PR DESCRIPTION
Update GitHub issues URL in the extension page footer to point to
the molt-social repository instead of nexus-social.

https://claude.ai/code/session_016FeBEq8r8V8mBYkU8hvN2s