### PR TITLE
feat: add AI impersonation prevention — interaction signals + report system

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,19 @@ enum NotificationType {
   DIRECT_MESSAGE
 }
 
+enum ReportReason {
+  AI_IMPERSONATION
+  SPAM
+  HARASSMENT
+  OTHER
+}
+
+enum ReportStatus {
+  PENDING
+  REVIEWED
+  DISMISSED
+}
+
 enum RegistrationStatus {
   PENDING
   CLAIMED
@@ -78,6 +91,8 @@ model User {
   conversationParticipants ConversationParticipant[]
   sentMessages             DirectMessage[]
   llmConfig                LlmConfig?
+  reportsMade              Report[]       @relation("reportsMade")
+  reportsReceived          Report[]       @relation("reportsReceived")
 }
 
 model Account {
@@ -139,8 +154,11 @@ model Post {
   sourceRelations   PostRelation[] @relation("sourceRelations")
   relatedRelations  PostRelation[] @relation("relatedRelations")
 
+  interactionSignals Json?
+
   agentProfileId String?
   agentProfile   AgentProfile? @relation(fields: [agentProfileId], references: [id], onDelete: SetNull)
+  reports        Report[]
 
   @@index([userId])
   @@index([createdAt])
@@ -164,8 +182,11 @@ model Reply {
   childReplies  Reply[] @relation("ReplyToReply")
   notifications Notification[]
 
+  interactionSignals Json?
+
   agentProfileId String?
   agentProfile   AgentProfile? @relation(fields: [agentProfileId], references: [id], onDelete: SetNull)
+  reports        Report[]
 
   @@index([postId])
   @@index([userId])
@@ -413,4 +434,28 @@ model LlmConfig {
 
   userId String @unique
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Report {
+  id        String       @id @default(cuid())
+  reason    ReportReason
+  details   String?      @db.VarChar(500)
+  status    ReportStatus @default(PENDING)
+  createdAt DateTime     @default(now())
+
+  reporterId   String
+  reporter     User   @relation("reportsMade", fields: [reporterId], references: [id], onDelete: Cascade)
+  targetUserId String?
+  targetUser   User?  @relation("reportsReceived", fields: [targetUserId], references: [id], onDelete: Cascade)
+  targetPostId String?
+  targetPost   Post?  @relation(fields: [targetPostId], references: [id], onDelete: Cascade)
+  targetReplyId String?
+  targetReply   Reply? @relation(fields: [targetReplyId], references: [id], onDelete: Cascade)
+
+  @@unique([reporterId, targetPostId])
+  @@unique([reporterId, targetReplyId])
+  @@unique([reporterId, targetUserId])
+  @@index([status])
+  @@index([reporterId])
+  @@index([targetUserId])
 }

--- a/src/app/api/posts/[postId]/replies/route.ts
+++ b/src/app/api/posts/[postId]/replies/route.ts
@@ -81,6 +81,7 @@ async function _POST(
         postId,
         userId: session.user.id,
         parentReplyId: parsed.data.parentReplyId,
+        interactionSignals: parsed.data.interactionSignals ?? undefined,
       },
       include: {
         user: {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -44,6 +44,7 @@ async function _POST(req: Request) {
       imageUrl: parsed.data.imageUrl,
       type: "HUMAN",
       userId: session.user.id,
+      interactionSignals: parsed.data.interactionSignals ?? undefined,
       ...(ogData && {
         linkPreviewUrl: ogData.linkPreviewUrl,
         linkPreviewImage: ogData.linkPreviewImage,

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { resolveSession } from "@/lib/mobile-auth";
+import { prisma } from "@/lib/prisma";
+import { createReportSchema, formatValidationError } from "@/lib/validators";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { withErrorHandling } from "@/lib/api-utils";
+
+async function _POST(req: Request) {
+  const session = await resolveSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const limited = checkRateLimit(req, "create-report", 10, session.user.id);
+  if (limited) return limited;
+
+  const body = await req.json();
+  const parsed = createReportSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: formatValidationError(parsed.error) },
+      { status: 400 }
+    );
+  }
+
+  const { reason, details, targetPostId, targetReplyId, targetUserId } =
+    parsed.data;
+
+  // Prevent self-reporting
+  if (targetUserId && targetUserId === session.user.id) {
+    return NextResponse.json(
+      { error: "You cannot report yourself" },
+      { status: 400 }
+    );
+  }
+
+  // Verify target exists
+  if (targetPostId) {
+    const post = await prisma.post.findUnique({ where: { id: targetPostId } });
+    if (!post) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+    if (post.userId === session.user.id) {
+      return NextResponse.json(
+        { error: "You cannot report your own post" },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (targetReplyId) {
+    const reply = await prisma.reply.findUnique({
+      where: { id: targetReplyId },
+    });
+    if (!reply) {
+      return NextResponse.json({ error: "Reply not found" }, { status: 404 });
+    }
+    if (reply.userId === session.user.id) {
+      return NextResponse.json(
+        { error: "You cannot report your own reply" },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (targetUserId) {
+    const user = await prisma.user.findUnique({ where: { id: targetUserId } });
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+  }
+
+  // Upsert to prevent duplicate reports (unique constraints handle this)
+  try {
+    const report = await prisma.report.create({
+      data: {
+        reason,
+        details: details || null,
+        reporterId: session.user.id,
+        targetPostId: targetPostId || null,
+        targetReplyId: targetReplyId || null,
+        targetUserId: targetUserId || null,
+      },
+    });
+
+    return NextResponse.json({ id: report.id }, { status: 201 });
+  } catch (err) {
+    // Prisma unique constraint violation — user already reported this target
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "You have already reported this" },
+        { status: 409 }
+      );
+    }
+    throw err;
+  }
+}
+
+export const POST = withErrorHandling(_POST);

--- a/src/components/layout/compose-modal.tsx
+++ b/src/components/layout/compose-modal.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useSession } from "next-auth/react";
 import { useCreatePost } from "@/hooks/use-create-post";
 import { useUploadImage } from "@/hooks/use-upload-image";
+import { useInteractionSignals } from "@/hooks/use-interaction-signals";
 import { useState, useRef, useCallback, useEffect } from "react";
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
@@ -29,6 +30,7 @@ export function ComposeModal({ open, onClose }: ComposeModalProps) {
   const blobUrlRef = useRef<string | null>(null);
   const { mutate: createPost, isPending } = useCreatePost();
   const { mutate: uploadImage, isPending: isUploading } = useUploadImage();
+  const signals = useInteractionSignals();
 
   const handleFile = useCallback(
     (file: File) => {
@@ -95,11 +97,13 @@ export function ComposeModal({ open, onClose }: ComposeModalProps) {
       {
         content: content.trim() || undefined,
         imageUrl: imageUrl || undefined,
+        interactionSignals: signals.getSignals(),
       },
       {
         onSuccess: () => {
           setContent("");
           removeImage();
+          signals.reset();
           onClose();
         },
       }
@@ -141,6 +145,9 @@ export function ComposeModal({ open, onClose }: ComposeModalProps) {
             placeholder="What's happening?"
             value={content}
             onChange={(e) => setContent(e.target.value)}
+            onKeyDown={signals.onKeyDown}
+            onPaste={signals.onPaste}
+            onFocus={signals.onFocus}
             className="min-h-[80px] text-base sm:min-h-[100px] sm:text-lg"
             maxLength={500}
           />

--- a/src/components/post/post-menu.tsx
+++ b/src/components/post/post-menu.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { useDeletePost } from "@/hooks/use-delete-post";
 import { EditPostModal } from "@/components/post/edit-post-modal";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { ReportDialog } from "@/components/ui/report-dialog";
 
 interface PostMenuProps {
   postId: string;
@@ -20,11 +21,13 @@ export function PostMenu({ postId, postUserId, postType, postContent, postImageU
   const [open, setOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const deletePost = useDeletePost();
 
   const isOwner = session?.user?.id === postUserId;
   const canModify = isOwner && postType === "HUMAN";
+  const canReport = !!session?.user?.id && !isOwner;
 
   useEffect(() => {
     if (!open) return;
@@ -37,7 +40,7 @@ export function PostMenu({ postId, postUserId, postType, postContent, postImageU
     return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
-  if (!canModify) return null;
+  if (!canModify && !canReport) return null;
 
   function handleDelete() {
     setConfirmDeleteOpen(false);
@@ -67,56 +70,88 @@ export function PostMenu({ postId, postUserId, postType, postContent, postImageU
 
         {open && (
           <div className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border border-border bg-background py-1 shadow-lg sm:w-48">
-            <button
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                setOpen(false);
-                setEditOpen(true);
-              }}
-              className="flex w-full items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-card-hover"
-            >
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-              Edit post
-            </button>
-            <button
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                setOpen(false);
-                setConfirmDeleteOpen(true);
-              }}
-              disabled={deletePost.isPending}
-              className="flex w-full items-center gap-2 px-4 py-2 text-sm text-red-500 hover:bg-card-hover disabled:opacity-50"
-            >
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-              {deletePost.isPending ? "Deleting..." : "Delete post"}
-            </button>
+            {canModify && (
+              <>
+                <button
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setOpen(false);
+                    setEditOpen(true);
+                  }}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-card-hover"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                  Edit post
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setOpen(false);
+                    setConfirmDeleteOpen(true);
+                  }}
+                  disabled={deletePost.isPending}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-red-500 hover:bg-card-hover disabled:opacity-50"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  {deletePost.isPending ? "Deleting..." : "Delete post"}
+                </button>
+              </>
+            )}
+            {canReport && (
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setOpen(false);
+                  setReportOpen(true);
+                }}
+                className="flex w-full items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-card-hover"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
+                </svg>
+                Report
+              </button>
+            )}
           </div>
         )}
       </div>
 
-      <EditPostModal
-        open={editOpen}
-        onClose={() => setEditOpen(false)}
-        postId={postId}
-        initialContent={postContent}
-        initialImageUrl={postImageUrl}
-      />
+      {canModify && (
+        <>
+          <EditPostModal
+            open={editOpen}
+            onClose={() => setEditOpen(false)}
+            postId={postId}
+            initialContent={postContent}
+            initialImageUrl={postImageUrl}
+          />
 
-      <ConfirmDialog
-        open={confirmDeleteOpen}
-        onClose={() => setConfirmDeleteOpen(false)}
-        onConfirm={handleDelete}
-        title="Delete post?"
-        description="This can't be undone. The post will be permanently removed."
-        confirmLabel="Delete"
-        isPending={deletePost.isPending}
-      />
+          <ConfirmDialog
+            open={confirmDeleteOpen}
+            onClose={() => setConfirmDeleteOpen(false)}
+            onConfirm={handleDelete}
+            title="Delete post?"
+            description="This can't be undone. The post will be permanently removed."
+            confirmLabel="Delete"
+            isPending={deletePost.isPending}
+          />
+        </>
+      )}
+
+      {canReport && (
+        <ReportDialog
+          open={reportOpen}
+          onClose={() => setReportOpen(false)}
+          targetPostId={postId}
+        />
+      )}
     </>
   );
 }

--- a/src/components/reply/reply-composer.tsx
+++ b/src/components/reply/reply-composer.tsx
@@ -6,6 +6,7 @@ import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { TextareaAuto } from "@/components/ui/textarea-auto";
 import { useCreateReply } from "@/hooks/use-create-reply";
+import { useInteractionSignals } from "@/hooks/use-interaction-signals";
 
 interface ReplyComposerProps {
   postId: string;
@@ -25,16 +26,18 @@ export function ReplyComposer({
   const { data: session } = useSession();
   const [content, setContent] = useState("");
   const { mutate: createReply, isPending } = useCreateReply(postId);
+  const signals = useInteractionSignals();
 
   if (!session) return null;
 
   const handleSubmit = () => {
     if (!content.trim()) return;
     createReply(
-      { content: content.trim(), parentReplyId },
+      { content: content.trim(), parentReplyId, interactionSignals: signals.getSignals() },
       {
         onSuccess: () => {
           setContent("");
+          signals.reset();
           onSuccess?.();
         },
       }
@@ -53,6 +56,9 @@ export function ReplyComposer({
           placeholder={placeholder}
           value={content}
           onChange={(e) => setContent(e.target.value)}
+          onKeyDown={signals.onKeyDown}
+          onPaste={signals.onPaste}
+          onFocus={signals.onFocus}
           className={compact ? "text-sm" : "text-base"}
           maxLength={500}
         />

--- a/src/components/ui/report-dialog.tsx
+++ b/src/components/ui/report-dialog.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { useReport } from "@/hooks/use-report";
+
+type ReportReason = "AI_IMPERSONATION" | "SPAM" | "HARASSMENT" | "OTHER";
+
+const REASONS: { value: ReportReason; label: string; description: string }[] = [
+  {
+    value: "AI_IMPERSONATION",
+    label: "AI impersonation",
+    description: "This account appears to be an AI pretending to be human",
+  },
+  {
+    value: "SPAM",
+    label: "Spam",
+    description: "Repetitive, unsolicited, or promotional content",
+  },
+  {
+    value: "HARASSMENT",
+    label: "Harassment",
+    description: "Abusive, threatening, or targeted behavior",
+  },
+  {
+    value: "OTHER",
+    label: "Other",
+    description: "Another issue not listed above",
+  },
+];
+
+interface ReportDialogProps {
+  open: boolean;
+  onClose: () => void;
+  targetPostId?: string;
+  targetReplyId?: string;
+  targetUserId?: string;
+}
+
+export function ReportDialog({
+  open,
+  onClose,
+  targetPostId,
+  targetReplyId,
+  targetUserId,
+}: ReportDialogProps) {
+  const [reason, setReason] = useState<ReportReason | null>(null);
+  const [details, setDetails] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const report = useReport();
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [open, handleKeyDown]);
+
+  useEffect(() => {
+    if (!open) {
+      setReason(null);
+      setDetails("");
+      setSubmitted(false);
+      report.reset();
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!open) return null;
+
+  const handleSubmit = () => {
+    if (!reason) return;
+    report.mutate(
+      {
+        reason,
+        details: details.trim() || undefined,
+        targetPostId,
+        targetReplyId,
+        targetUserId,
+      },
+      {
+        onSuccess: () => setSubmitted(true),
+      }
+    );
+  };
+
+  if (submitted) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+        <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+        <div className="animate-in relative z-10 w-full max-w-sm rounded-xl border border-border bg-background p-6">
+          <h3 className="text-lg font-semibold text-foreground">
+            Report submitted
+          </h3>
+          <p className="mt-2 text-sm text-muted">
+            Thanks for helping keep the community safe. We&apos;ll review this
+            report.
+          </p>
+          <div className="mt-6 flex justify-end">
+            <Button size="sm" onClick={onClose}>
+              Done
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+      <div className="animate-in relative z-10 w-full max-w-sm rounded-xl border border-border bg-background p-6">
+        <h3 className="text-lg font-semibold text-foreground">
+          Report content
+        </h3>
+        <p className="mt-1 text-sm text-muted">
+          Why are you reporting this?
+        </p>
+
+        <div className="mt-4 space-y-2">
+          {REASONS.map((r) => (
+            <label
+              key={r.value}
+              className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors ${
+                reason === r.value
+                  ? "border-cyan bg-cyan/5"
+                  : "border-border hover:bg-card-hover/50"
+              }`}
+            >
+              <input
+                type="radio"
+                name="report-reason"
+                value={r.value}
+                checked={reason === r.value}
+                onChange={() => setReason(r.value)}
+                className="mt-0.5 accent-cyan"
+              />
+              <div>
+                <span className="text-sm font-medium text-foreground">
+                  {r.label}
+                </span>
+                <p className="text-xs text-muted">{r.description}</p>
+              </div>
+            </label>
+          ))}
+        </div>
+
+        <textarea
+          placeholder="Additional details (optional)"
+          value={details}
+          onChange={(e) => setDetails(e.target.value)}
+          maxLength={500}
+          className="mt-3 w-full rounded-lg border border-border bg-transparent px-3 py-2 text-sm text-foreground placeholder-muted focus:border-cyan focus:outline-none"
+          rows={2}
+        />
+
+        {report.isError && (
+          <p className="mt-2 text-sm text-red-400">{report.error.message}</p>
+        )}
+
+        <div className="mt-4 flex justify-end gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            disabled={report.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!reason || report.isPending}
+          >
+            {report.isPending ? "Submitting..." : "Submit report"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-create-post.ts
+++ b/src/hooks/use-create-post.ts
@@ -1,12 +1,13 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { InteractionSignals } from "@/hooks/use-interaction-signals";
 
 export function useCreatePost() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: { content?: string; imageUrl?: string }) => {
+    mutationFn: async (data: { content?: string; imageUrl?: string; interactionSignals?: InteractionSignals }) => {
       const res = await fetch("/api/posts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/hooks/use-create-reply.ts
+++ b/src/hooks/use-create-reply.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { InteractionSignals } from "@/hooks/use-interaction-signals";
 
 export function useCreateReply(postId: string) {
   const queryClient = useQueryClient();
@@ -9,6 +10,7 @@ export function useCreateReply(postId: string) {
     mutationFn: async (data: {
       content: string;
       parentReplyId?: string;
+      interactionSignals?: InteractionSignals;
     }) => {
       const res = await fetch(`/api/posts/${postId}/replies`, {
         method: "POST",

--- a/src/hooks/use-interaction-signals.ts
+++ b/src/hooks/use-interaction-signals.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { useRef, useCallback, useEffect } from "react";
+
+export interface InteractionSignals {
+  /** Total keystrokes recorded in the compose area */
+  keystrokeCount: number;
+  /** Number of paste events */
+  pasteCount: number;
+  /** Time in ms between first focus and submission */
+  composeDurationMs: number;
+  /** Number of focus/blur cycles on the textarea */
+  focusCycleCount: number;
+  /** Whether the page had mouse movement (coarse entropy indicator) */
+  hadMouseMovement: boolean;
+  /** Number of scroll events on the page during compose */
+  scrollEventCount: number;
+  /** Average time between keystrokes in ms (0 if < 2 keystrokes) */
+  avgKeystrokeIntervalMs: number;
+}
+
+/**
+ * Tracks behavioral signals during text composition.
+ * Attach the returned ref callbacks to the compose textarea,
+ * and call getSignals() before submission.
+ */
+export function useInteractionSignals() {
+  const keystrokeCount = useRef(0);
+  const pasteCount = useRef(0);
+  const focusCycleCount = useRef(0);
+  const firstFocusTime = useRef<number | null>(null);
+  const hadMouseMovement = useRef(false);
+  const scrollEventCount = useRef(0);
+  const keystrokeTimestamps = useRef<number[]>([]);
+
+  // Track page-level mouse movement
+  useEffect(() => {
+    let moveCount = 0;
+    const onMouseMove = () => {
+      moveCount++;
+      if (moveCount >= 3) {
+        hadMouseMovement.current = true;
+      }
+    };
+    const onScroll = () => {
+      scrollEventCount.current++;
+    };
+    window.addEventListener("mousemove", onMouseMove, { passive: true });
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  const onKeyDown = useCallback(() => {
+    keystrokeCount.current++;
+    keystrokeTimestamps.current.push(Date.now());
+  }, []);
+
+  const onPaste = useCallback(() => {
+    pasteCount.current++;
+  }, []);
+
+  const onFocus = useCallback(() => {
+    if (firstFocusTime.current === null) {
+      firstFocusTime.current = Date.now();
+    }
+    focusCycleCount.current++;
+  }, []);
+
+  const getSignals = useCallback((): InteractionSignals => {
+    const now = Date.now();
+    const composeDurationMs = firstFocusTime.current
+      ? now - firstFocusTime.current
+      : 0;
+
+    const timestamps = keystrokeTimestamps.current;
+    let avgKeystrokeIntervalMs = 0;
+    if (timestamps.length >= 2) {
+      let totalInterval = 0;
+      for (let i = 1; i < timestamps.length; i++) {
+        totalInterval += timestamps[i] - timestamps[i - 1];
+      }
+      avgKeystrokeIntervalMs = Math.round(
+        totalInterval / (timestamps.length - 1)
+      );
+    }
+
+    return {
+      keystrokeCount: keystrokeCount.current,
+      pasteCount: pasteCount.current,
+      composeDurationMs,
+      focusCycleCount: focusCycleCount.current,
+      hadMouseMovement: hadMouseMovement.current,
+      scrollEventCount: scrollEventCount.current,
+      avgKeystrokeIntervalMs,
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    keystrokeCount.current = 0;
+    pasteCount.current = 0;
+    focusCycleCount.current = 0;
+    firstFocusTime.current = null;
+    scrollEventCount.current = 0;
+    keystrokeTimestamps.current = [];
+    // Don't reset hadMouseMovement - it's page-level
+  }, []);
+
+  return { onKeyDown, onPaste, onFocus, getSignals, reset };
+}

--- a/src/hooks/use-report.ts
+++ b/src/hooks/use-report.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+
+interface ReportData {
+  reason: "AI_IMPERSONATION" | "SPAM" | "HARASSMENT" | "OTHER";
+  details?: string;
+  targetPostId?: string;
+  targetReplyId?: string;
+  targetUserId?: string;
+}
+
+export function useReport() {
+  return useMutation({
+    mutationFn: async (data: ReportData) => {
+      const res = await fetch("/api/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error || "Failed to submit report");
+      }
+      return res.json();
+    },
+  });
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -10,10 +10,21 @@ export function formatValidationError(error: ZodError): string {
   return flattened.formErrors[0] || "Validation failed";
 }
 
+export const interactionSignalsSchema = z.object({
+  keystrokeCount: z.number().int().min(0),
+  pasteCount: z.number().int().min(0),
+  composeDurationMs: z.number().int().min(0),
+  focusCycleCount: z.number().int().min(0),
+  hadMouseMovement: z.boolean(),
+  scrollEventCount: z.number().int().min(0),
+  avgKeystrokeIntervalMs: z.number().int().min(0),
+}).optional();
+
 export const createPostSchema = z
   .object({
     content: z.string().max(500).optional(),
     imageUrl: z.string().url().optional(),
+    interactionSignals: interactionSignalsSchema,
   })
   .refine((data) => data.content || data.imageUrl, {
     message: "Post must have content or an image",
@@ -24,6 +35,7 @@ export const editPostSchema = createPostSchema;
 export const createReplySchema = z.object({
   content: z.string().min(1).max(500),
   parentReplyId: z.string().optional(),
+  interactionSignals: interactionSignalsSchema,
 });
 
 export const agentPostSchema = z.object({
@@ -140,6 +152,21 @@ export const agentStartConversationSchema = z.object({
   recipientAgentSlug: z.string(),
   content: z.string().min(1).max(2000),
 });
+
+export const createReportSchema = z
+  .object({
+    reason: z.enum(["AI_IMPERSONATION", "SPAM", "HARASSMENT", "OTHER"]),
+    details: z.string().max(500).optional(),
+    targetPostId: z.string().optional(),
+    targetReplyId: z.string().optional(),
+    targetUserId: z.string().optional(),
+  })
+  .refine(
+    (data) =>
+      [data.targetPostId, data.targetReplyId, data.targetUserId].filter(Boolean)
+        .length === 1,
+    { message: "Provide exactly one of targetPostId, targetReplyId, or targetUserId" }
+  );
 
 export const mobileTokenExchangeSchema = z.object({
   provider: z.enum(["google", "github"]),


### PR DESCRIPTION
Two defense layers against AI agents impersonating human users:

1. Client-side interaction signals: A useInteractionSignals hook tracks
   behavioral data (keystroke count, timing, paste events, mouse movement,
   scroll activity, compose duration) and submits it alongside posts and
   replies. Stored as JSON on Post/Reply for analysis.

2. Community reporting: Users can report posts via a "Report" option in
   the post menu (visible to non-owners). Supports AI_IMPERSONATION,
   SPAM, HARASSMENT, and OTHER reasons with optional details. Reports
   are deduplicated per reporter+target and rate-limited.

https://claude.ai/code/session_01TmhcvLTovgYhTi9vcGXbyG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted data models and a new write endpoint with rate-limiting and unique constraints, which can affect DB migrations and moderation workflows if validation/dedupe logic is wrong.
> 
> **Overview**
> Adds *behavioral interaction signal* capture on post/reply composition, sending a new optional `interactionSignals` payload (keystrokes/timing/paste/mouse/scroll) through the create post/reply APIs and persisting it as JSON on `Post` and `Reply`.
> 
> Introduces a new *community reporting* flow: a `Report` Prisma model + enums (`ReportReason`, `ReportStatus`) with dedupe constraints per reporter/target, a new `POST /api/reports` endpoint that validates exactly one target, blocks self/own-content reports, rate-limits submissions, and returns 409 on duplicates; plus a new `Report` action in the post menu backed by a `ReportDialog` UI and `useReport` hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5de2ee4006a2bf89f93ead3d33fe0e9cf1d1640. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->