### PR TITLE
Fix feed scroll pagination for For You and Explore tabs

### DIFF
--- a/src/lib/feed-engine/index.ts
+++ b/src/lib/feed-engine/index.ts
@@ -20,10 +20,13 @@ export async function getScoredFeed(options: FeedOptions = {}): Promise<FeedResu
   const sql = buildScoredFeedQuery(cursor, limit, postType);
   const rows = await executeRankedQuery(prisma, sql);
 
-  const hasMore = rows.length > limit;
-  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  // Diversity filtering (author cap) can reduce rows well below `limit`,
+  // so rows.length <= limit does NOT mean there are no more posts.
+  // Always return a cursor when we have posts; the next page returns empty
+  // to signal the true end.
+  const pageRows = rows.length > limit ? rows.slice(0, limit) : rows;
   const nextCursor =
-    hasMore && pageRows.length > 0
+    pageRows.length > 0
       ? encodeCursor(
           pageRows[pageRows.length - 1].score,
           pageRows[pageRows.length - 1].id
@@ -51,10 +54,9 @@ export async function getForYouFeed(
   const sql = buildForYouQuery(personalization, cursor, limit, postType);
   const rows = await executeRankedQuery(prisma, sql);
 
-  const hasMore = rows.length > limit;
-  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const pageRows = rows.length > limit ? rows.slice(0, limit) : rows;
   const nextCursor =
-    hasMore && pageRows.length > 0
+    pageRows.length > 0
       ? encodeCursor(
           pageRows[pageRows.length - 1].score,
           pageRows[pageRows.length - 1].id

--- a/src/lib/feed-engine/types.ts
+++ b/src/lib/feed-engine/types.ts
@@ -25,7 +25,7 @@ export const FEED_CONFIG = {
   FRESHNESS_FLOOR_HOURS: 1, // "recent" = within this many hours
 
   // Query bounds
-  TIME_WINDOW_DAYS: 7,
+  TIME_WINDOW_DAYS: 30,
   DEFAULT_LIMIT: 20,
   MAX_INTEREST_LIKES: 200,
   MAX_FOLLOW_IDS: 500,


### PR DESCRIPTION
The diversity wrapper (author cap of 3 posts per author) can reduce query
results well below the page limit of 20. The old hasMore check
(rows.length > limit) would incorrectly report no more pages, stopping
pagination at just a few posts.

Fix: always return a cursor when posts exist so pagination continues until
the underlying query returns empty. Also widen TIME_WINDOW_DAYS from 7 to
30 so more posts are eligible for ranking.

https://claude.ai/code/session_01G5i6SxADRoWe2dwicK3Udp