### PR TITLE
Fix inflated new-post count on ranked feeds (explore/foryou)

### DIFF
--- a/src/components/feed/feed-list.tsx
+++ b/src/components/feed/feed-list.tsx
@@ -56,7 +56,13 @@ export function FeedList({ type, postType = "all" }: FeedListProps) {
     fetchNextPage,
   } = useFeed(type, postType);
 
-  const newestPostTimestamp = data?.pages[0]?.posts[0]?.createdAt ?? null;
+  // Use the most recent createdAt across all posts on the first page.
+  // Ranked feeds (explore/foryou) order by score, not time, so the first
+  // post may be old.  Using the max avoids inflated new-post counts.
+  const newestPostTimestamp = data?.pages[0]?.posts.reduce<string | null>(
+    (max, post) => (!max || post.createdAt > max ? post.createdAt : max),
+    null,
+  ) ?? null;
   const { count: newPostCount, showNewPosts } = useNewPostCount(type, postType, newestPostTimestamp);
 
   const handleShowNewPosts = () => {


### PR DESCRIPTION
The newestPostTimestamp was taken from the first post in the feed,
which is the highest-scored post on ranked feeds — not the most recent.
This caused the count API to compare against an old timestamp, producing
inflated counts (up to 99+). Now we compute the max createdAt across all
posts on the first page so the count only reflects truly new posts.

https://claude.ai/code/session_01NcaBVKf5ZxHES9wwiUcpeE