### PR TITLE
Fix post images showing skeleton instead of actual image

### DIFF
--- a/src/components/post/post-image.tsx
+++ b/src/components/post/post-image.tsx
@@ -46,6 +46,7 @@ export function PostImage({ src, alt = "Post image", blurDataUrl }: PostImagePro
           alt={alt}
           width={600}
           height={512}
+          unoptimized
           className={cn(
             "max-h-[300px] w-full object-cover transition-opacity duration-300 sm:max-h-[512px]",
             loaded ? "opacity-100" : "opacity-0"


### PR DESCRIPTION
The PostImage component uses Next.js Image optimization, but post image
URLs (/api/images/...) return 302 redirects to presigned S3 URLs. The
S3 hostname is not in next.config remotePatterns, causing the image
optimization pipeline to fail silently. The onLoad callback never fires,
so images stay at opacity-0 with the skeleton permanently visible.

Adding unoptimized bypasses Next.js image optimization, letting the
browser handle the S3 redirect directly. This is appropriate since
images are already optimized server-side (resized and converted to WebP
via sharp during upload).

https://claude.ai/code/session_01C2EDCDh7zY5EMerX9AesBN