### PR TITLE
Fix P1 performance and accessibility issues (#5-12)

### DIFF
--- a/src/app/(main)/admin/keys/loading.tsx
+++ b/src/app/(main)/admin/keys/loading.tsx
@@ -1,0 +1,25 @@
+export default function AdminKeysLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="h-6 w-28 rounded bg-border" />
+      </div>
+      <div className="p-4 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-10 flex-1 rounded-lg bg-border" />
+        </div>
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="flex items-center gap-4 rounded-lg border border-border p-3">
+              <div className="flex-1 space-y-1">
+                <div className="h-4 w-40 rounded bg-border" />
+                <div className="h-3 w-56 rounded bg-border" />
+              </div>
+              <div className="h-8 w-8 rounded bg-border" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/admin/loading.tsx
+++ b/src/app/(main)/admin/loading.tsx
@@ -1,0 +1,25 @@
+export default function AdminLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="h-6 w-20 rounded bg-border" />
+      </div>
+      <div className="p-4 space-y-4">
+        <div className="flex gap-2">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="h-8 w-20 rounded-lg bg-border" />
+          ))}
+        </div>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="rounded-xl border border-border p-4 space-y-2">
+              <div className="h-3 w-16 rounded bg-border" />
+              <div className="h-6 w-12 rounded bg-border" />
+            </div>
+          ))}
+        </div>
+        <div className="h-48 rounded-xl border border-border bg-border" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/admin/posts/loading.tsx
+++ b/src/app/(main)/admin/posts/loading.tsx
@@ -1,0 +1,28 @@
+export default function AdminPostsLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="h-6 w-28 rounded bg-border" />
+      </div>
+      <div className="p-4 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-10 flex-1 rounded-lg bg-border" />
+          <div className="h-10 w-28 rounded-lg bg-border" />
+        </div>
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="flex items-center gap-4 rounded-lg border border-border p-3">
+              <div className="h-8 w-8 rounded-full bg-border" />
+              <div className="flex-1 space-y-1">
+                <div className="h-4 w-48 rounded bg-border" />
+                <div className="h-3 w-32 rounded bg-border" />
+              </div>
+              <div className="h-3 w-16 rounded bg-border" />
+              <div className="h-8 w-8 rounded bg-border" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/admin/proposals/loading.tsx
+++ b/src/app/(main)/admin/proposals/loading.tsx
@@ -1,0 +1,27 @@
+export default function AdminProposalsLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="h-6 w-36 rounded bg-border" />
+      </div>
+      <div className="p-4 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-10 flex-1 rounded-lg bg-border" />
+          <div className="h-10 w-28 rounded-lg bg-border" />
+        </div>
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="flex items-center gap-4 rounded-lg border border-border p-3">
+              <div className="h-5 w-16 rounded-full bg-border" />
+              <div className="flex-1 space-y-1">
+                <div className="h-4 w-48 rounded bg-border" />
+                <div className="h-3 w-32 rounded bg-border" />
+              </div>
+              <div className="h-8 w-8 rounded bg-border" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/admin/replies/loading.tsx
+++ b/src/app/(main)/admin/replies/loading.tsx
@@ -1,0 +1,27 @@
+export default function AdminRepliesLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="h-6 w-28 rounded bg-border" />
+      </div>
+      <div className="p-4 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-10 flex-1 rounded-lg bg-border" />
+          <div className="h-10 w-28 rounded-lg bg-border" />
+        </div>
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="flex items-center gap-4 rounded-lg border border-border p-3">
+              <div className="h-8 w-8 rounded-full bg-border" />
+              <div className="flex-1 space-y-1">
+                <div className="h-4 w-48 rounded bg-border" />
+                <div className="h-3 w-32 rounded bg-border" />
+              </div>
+              <div className="h-8 w-8 rounded bg-border" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/admin/users/loading.tsx
+++ b/src/app/(main)/admin/users/loading.tsx
@@ -1,0 +1,28 @@
+export default function AdminUsersLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="h-6 w-28 rounded bg-border" />
+      </div>
+      <div className="p-4 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-10 flex-1 rounded-lg bg-border" />
+          <div className="h-10 w-28 rounded-lg bg-border" />
+        </div>
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="flex items-center gap-4 rounded-lg border border-border p-3">
+              <div className="h-8 w-8 rounded-full bg-border" />
+              <div className="flex-1 space-y-1">
+                <div className="h-4 w-32 rounded bg-border" />
+                <div className="h-3 w-24 rounded bg-border" />
+              </div>
+              <div className="h-3 w-16 rounded bg-border" />
+              <div className="h-8 w-8 rounded bg-border" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/agent/[slug]/loading.tsx
+++ b/src/app/(main)/agent/[slug]/loading.tsx
@@ -1,0 +1,40 @@
+export default function AgentProfileLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-center gap-4">
+          <div className="h-5 w-5 rounded bg-border" />
+          <div className="h-5 w-32 rounded bg-border" />
+        </div>
+      </div>
+      <div className="p-4">
+        <div className="flex items-start gap-4">
+          <div className="h-20 w-20 shrink-0 rounded-full bg-border" />
+          <div className="flex-1 space-y-2">
+            <div className="h-6 w-40 rounded bg-border" />
+            <div className="h-4 w-24 rounded bg-border" />
+            <div className="h-3 w-full rounded bg-border" />
+            <div className="h-3 w-2/3 rounded bg-border" />
+          </div>
+        </div>
+        <div className="mt-4 flex gap-6">
+          <div className="h-4 w-20 rounded bg-border" />
+          <div className="h-4 w-20 rounded bg-border" />
+          <div className="h-4 w-20 rounded bg-border" />
+        </div>
+      </div>
+      <div className="border-t border-border">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="border-b border-border p-4 space-y-2">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-full bg-border" />
+              <div className="h-4 w-28 rounded bg-border" />
+            </div>
+            <div className="h-3 w-full rounded bg-border" />
+            <div className="h-3 w-3/4 rounded bg-border" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/agent/[slug]/page.tsx
+++ b/src/app/(main)/agent/[slug]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useParams } from "next/navigation";
 import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
 import { useState } from "react";
@@ -13,7 +14,11 @@ import { InfiniteScroll } from "@/components/ui/infinite-scroll";
 import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
 import { AgentReviews } from "@/components/marketplace/agent-reviews";
-import { RatingModal } from "@/components/marketplace/rating-modal";
+
+const RatingModal = dynamic(
+  () => import("@/components/marketplace/rating-modal").then((m) => m.RatingModal),
+  { ssr: false }
+);
 import type { PostData } from "@/hooks/use-feed";
 
 interface AgentProfileData {

--- a/src/app/(main)/dashboard/loading.tsx
+++ b/src/app/(main)/dashboard/loading.tsx
@@ -1,0 +1,20 @@
+export default function DashboardLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="h-6 w-28 rounded bg-border" />
+        <div className="mt-1 h-3 w-48 rounded bg-border" />
+      </div>
+      <div className="space-y-4 p-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="rounded-xl border border-border p-4 space-y-3">
+            <div className="h-5 w-36 rounded bg-border" />
+            <div className="h-3 w-full rounded bg-border" />
+            <div className="h-3 w-2/3 rounded bg-border" />
+            <div className="h-10 w-28 rounded-lg bg-border" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/governance/layout.tsx
+++ b/src/app/(main)/governance/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Governance | Molt",
+  description:
+    "Vote on feature proposals and shape the future of Molt. Community-driven governance for humans and AI agents.",
+  openGraph: {
+    title: "Governance | Molt",
+    description:
+      "Vote on feature proposals and shape the future of Molt.",
+  },
+};
+
+export default function GovernanceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/(main)/governance/loading.tsx
+++ b/src/app/(main)/governance/loading.tsx
@@ -1,0 +1,36 @@
+export default function GovernanceLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="sticky top-0 z-10 border-b border-border bg-background/80 backdrop-blur">
+        <div className="flex items-center justify-between px-4 py-3">
+          <div className="h-6 w-28 rounded bg-border" />
+          <div className="h-8 w-20 rounded-lg bg-border" />
+        </div>
+        <div className="flex border-b border-border">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="flex-1 py-3 flex justify-center">
+              <div className="h-4 w-20 rounded bg-border" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="divide-y divide-border">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="p-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-16 rounded-full bg-border" />
+              <div className="h-3 w-24 rounded bg-border" />
+            </div>
+            <div className="h-5 w-3/4 rounded bg-border" />
+            <div className="h-3 w-full rounded bg-border" />
+            <div className="h-3 w-1/2 rounded bg-border" />
+            <div className="flex gap-3">
+              <div className="h-8 w-20 rounded-lg bg-border" />
+              <div className="h-8 w-20 rounded-lg bg-border" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/governance/page.tsx
+++ b/src/app/(main)/governance/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { Tabs } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { ProposalList } from "@/components/governance/proposal-list";
-import { CreateProposalModal } from "@/components/governance/create-proposal-modal";
+
+const CreateProposalModal = dynamic(
+  () => import("@/components/governance/create-proposal-modal").then((m) => m.CreateProposalModal),
+  { ssr: false }
+);
 
 const tabs = [
   { label: "Open", value: "OPEN" },

--- a/src/app/(main)/marketplace/layout.tsx
+++ b/src/app/(main)/marketplace/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Agent Marketplace | Molt",
+  description:
+    "Discover and follow AI agents built by the community on Molt. Browse by category, rating, and popularity.",
+  openGraph: {
+    title: "Agent Marketplace | Molt",
+    description:
+      "Discover and follow AI agents built by the community on Molt.",
+  },
+};
+
+export default function MarketplaceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/(main)/marketplace/loading.tsx
+++ b/src/app/(main)/marketplace/loading.tsx
@@ -1,0 +1,46 @@
+export default function MarketplaceLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="sticky top-0 z-10 border-b border-border bg-background/80 backdrop-blur">
+        <div className="px-4 py-3">
+          <div className="h-6 w-40 rounded bg-border" />
+          <div className="mt-1 h-3 w-56 rounded bg-border" />
+        </div>
+        <div className="px-4 pb-3">
+          <div className="h-10 w-full rounded-lg bg-border" />
+        </div>
+        <div className="flex gap-2 px-4 pb-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-7 w-20 shrink-0 rounded-full bg-border" />
+          ))}
+        </div>
+        <div className="flex border-b border-border">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex-1 py-3 flex justify-center">
+              <div className="h-4 w-16 rounded bg-border" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-3 p-4">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="rounded-xl border border-border p-4 space-y-3">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-full bg-border" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-32 rounded bg-border" />
+                <div className="h-3 w-20 rounded bg-border" />
+              </div>
+            </div>
+            <div className="h-3 w-full rounded bg-border" />
+            <div className="h-3 w-2/3 rounded bg-border" />
+            <div className="flex gap-4">
+              <div className="h-3 w-16 rounded bg-border" />
+              <div className="h-3 w-16 rounded bg-border" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/messages/[conversationId]/loading.tsx
+++ b/src/app/(main)/messages/[conversationId]/loading.tsx
@@ -1,0 +1,27 @@
+export default function ConversationLoading() {
+  return (
+    <div className="flex h-full flex-col animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-center gap-3">
+          <div className="h-5 w-5 rounded bg-border" />
+          <div className="h-10 w-10 rounded-full bg-border" />
+          <div className="h-4 w-24 rounded bg-border" />
+        </div>
+      </div>
+      <div className="flex-1 space-y-3 p-4">
+        <div className="flex gap-2">
+          <div className="h-8 w-8 rounded-full bg-border" />
+          <div className="h-16 w-48 rounded-2xl bg-border" />
+        </div>
+        <div className="flex flex-row-reverse gap-2">
+          <div className="h-8 w-8 rounded-full bg-border" />
+          <div className="h-10 w-36 rounded-2xl bg-border" />
+        </div>
+        <div className="flex gap-2">
+          <div className="h-8 w-8 rounded-full bg-border" />
+          <div className="h-12 w-56 rounded-2xl bg-border" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/messages/loading.tsx
+++ b/src/app/(main)/messages/loading.tsx
@@ -1,0 +1,21 @@
+export default function MessagesLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="border-b border-border px-4 py-3">
+        <div className="h-6 w-28 rounded bg-border" />
+      </div>
+      <div className="divide-y divide-border">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="flex items-center gap-3 p-4">
+            <div className="h-12 w-12 shrink-0 rounded-full bg-border" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-32 rounded bg-border" />
+              <div className="h-3 w-48 rounded bg-border" />
+            </div>
+            <div className="h-3 w-10 rounded bg-border" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/post/[postId]/page.tsx
+++ b/src/app/(main)/post/[postId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -13,8 +14,12 @@ import { PostMenu } from "@/components/post/post-menu";
 import { ReplyComposer } from "@/components/reply/reply-composer";
 import { ReplyThread } from "@/components/reply/reply-thread";
 import { RelatedPostsCarousel } from "@/components/post/related-posts-carousel";
-import { PostAiPanel } from "@/components/post/post-ai-panel";
 import { InfiniteScroll } from "@/components/ui/infinite-scroll";
+
+const PostAiPanel = dynamic(
+  () => import("@/components/post/post-ai-panel").then((m) => m.PostAiPanel),
+  { ssr: false }
+);
 import { useAiSummary } from "@/components/providers/ai-summary-provider";
 import { useIsRightPanelVisible } from "@/hooks/use-media-query";
 import { Spinner } from "@/components/ui/spinner";

--- a/src/app/(main)/search/layout.tsx
+++ b/src/app/(main)/search/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Search | Molt",
+  description:
+    "Search for people and posts on Molt. Find users, AI agents, and conversations across the platform.",
+  openGraph: {
+    title: "Search | Molt",
+    description:
+      "Search for people and posts on Molt.",
+  },
+};
+
+export default function SearchLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/api/agent/feed/route.ts
+++ b/src/app/api/agent/feed/route.ts
@@ -75,7 +75,7 @@ async function _GET(req: NextRequest) {
   const items = hasMore ? posts.slice(0, limit) : posts;
   const nextCursor = hasMore ? items[items.length - 1].id : null;
 
-  return NextResponse.json({
+  const res = NextResponse.json({
     posts: items.map((p) => ({
       ...p,
       user: resolveAvatar(p.user),
@@ -84,5 +84,7 @@ async function _GET(req: NextRequest) {
     })),
     nextCursor,
   });
+  res.headers.set("Cache-Control", "public, s-maxage=15, stale-while-revalidate=30");
+  return res;
 }
 export const GET = withErrorHandling(_GET);

--- a/src/app/api/marketplace/route.ts
+++ b/src/app/api/marketplace/route.ts
@@ -141,7 +141,9 @@ async function _GET(req: Request) {
     isFollowing: followedIds.has(agent.id),
   }));
 
-  return NextResponse.json({ agents: data, nextCursor });
+  const res = NextResponse.json({ agents: data, nextCursor });
+  res.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=120");
+  return res;
 }
 
 export const GET = withErrorHandling(_GET);

--- a/src/app/api/posts/[postId]/related/route.ts
+++ b/src/app/api/posts/[postId]/related/route.ts
@@ -50,6 +50,8 @@ async function _GET(
     Object.assign(serializePost(r.relatedPost), { score: r.score })
   );
 
-  return NextResponse.json({ posts });
+  const res = NextResponse.json({ posts });
+  res.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=600");
+  return res;
 }
 export const GET = withErrorHandling(_GET);

--- a/src/app/api/posts/[postId]/replies/route.ts
+++ b/src/app/api/posts/[postId]/replies/route.ts
@@ -33,7 +33,7 @@ async function _GET(
   const items = hasMore ? replies.slice(0, limit) : replies;
   const nextCursor = hasMore ? items[items.length - 1].id : null;
 
-  return NextResponse.json({
+  const res = NextResponse.json({
     replies: items.map((r) => ({
       ...r,
       user: resolveAvatar(r.user),
@@ -42,6 +42,8 @@ async function _GET(
     })),
     nextCursor,
   });
+  res.headers.set("Cache-Control", "public, s-maxage=15, stale-while-revalidate=30");
+  return res;
 }
 export const GET = withErrorHandling(_GET);
 

--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -70,12 +70,14 @@ async function _GET(req: Request) {
       : null,
   }));
 
-  return NextResponse.json({
+  const res = NextResponse.json({
     proposals: data,
     nextCursor,
     activeUserCount,
     threshold,
   });
+  res.headers.set("Cache-Control", "public, s-maxage=30, stale-while-revalidate=60");
+  return res;
 }
 export const GET = withErrorHandling(_GET);
 

--- a/src/app/api/users/[username]/posts/route.ts
+++ b/src/app/api/users/[username]/posts/route.ts
@@ -98,9 +98,11 @@ async function _GET(
   const items = hasMore ? posts.slice(0, limit) : posts;
   const nextCursor = hasMore ? items[items.length - 1].id : null;
 
-  return NextResponse.json({
+  const res = NextResponse.json({
     posts: items.map(serializePost),
     nextCursor,
   });
+  res.headers.set("Cache-Control", "public, s-maxage=30, stale-while-revalidate=60");
+  return res;
 }
 export const GET = withErrorHandling(_GET);

--- a/src/components/layout/mobile-compose-button.tsx
+++ b/src/components/layout/mobile-compose-button.tsx
@@ -1,8 +1,13 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState } from "react";
 import { useSession } from "next-auth/react";
-import { ComposeModal } from "@/components/layout/compose-modal";
+
+const ComposeModal = dynamic(
+  () => import("@/components/layout/compose-modal").then((m) => m.ComposeModal),
+  { ssr: false }
+);
 
 export function MobileComposeButton() {
   const { data: session } = useSession();

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -55,10 +55,10 @@ export function MobileNav() {
 
   return (
     <>
-    <nav className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-background/95 backdrop-blur-md lg:hidden safe-area-bottom">
-      <div className="flex">
+    <nav aria-label="Mobile navigation" className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-background/95 backdrop-blur-md lg:hidden safe-area-bottom">
+      <div className="flex" role="tablist">
         {/* Home */}
-        <Link href="/" className={navLinkClass(isHome)}>
+        <Link href="/" className={navLinkClass(isHome)} aria-label="Home" aria-current={isHome ? "page" : undefined}>
           <svg className="h-6 w-6" fill={isHome ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={isHome ? 0 : 2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1" />
           </svg>
@@ -66,7 +66,7 @@ export function MobileNav() {
         </Link>
 
         {/* Search */}
-        <Link href="/search" className={navLinkClass(isSearch)}>
+        <Link href="/search" className={navLinkClass(isSearch)} aria-label="Search" aria-current={isSearch ? "page" : undefined}>
           <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth={isSearch ? 2.5 : 2} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
@@ -75,7 +75,7 @@ export function MobileNav() {
 
         {/* Notifications (auth only) */}
         {session && (
-          <Link href="/notifications" className={cn(navLinkClass(isNotifications), "relative")}>
+          <Link href="/notifications" className={cn(navLinkClass(isNotifications), "relative")} aria-label={`Notifications${(unreadData?.count ?? 0) > 0 ? `, ${unreadData!.count} unread` : ""}`} aria-current={isNotifications ? "page" : undefined}>
             <svg className="h-6 w-6" fill={isNotifications ? "currentColor" : "none"} stroke="currentColor" strokeWidth={isNotifications ? 0 : 2} viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
             </svg>
@@ -90,7 +90,7 @@ export function MobileNav() {
 
         {/* Messages (auth only) */}
         {session && (
-          <Link href="/messages" className={cn(navLinkClass(isMessages), "relative")}>
+          <Link href="/messages" className={cn(navLinkClass(isMessages), "relative")} aria-label={`Messages${(unreadMsgData?.count ?? 0) > 0 ? `, ${unreadMsgData!.count} unread` : ""}`} aria-current={isMessages ? "page" : undefined}>
             <svg className="h-6 w-6" fill={isMessages ? "currentColor" : "none"} stroke="currentColor" strokeWidth={isMessages ? 0 : 2} viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
             </svg>
@@ -108,6 +108,9 @@ export function MobileNav() {
           <div ref={menuRef} className="relative flex flex-1 items-center justify-center">
             <button
               onClick={() => setMenuOpen((prev) => !prev)}
+              aria-label="Profile menu"
+              aria-expanded={menuOpen}
+              aria-haspopup="true"
               className={cn(
                 "flex flex-col items-center justify-center gap-0.5 py-3 transition-colors",
                 isProfile || menuOpen ? "text-cyan" : "text-muted active:text-foreground"
@@ -135,7 +138,7 @@ export function MobileNav() {
               <span className="text-[10px] font-medium">Profile</span>
             </button>
             {menuOpen && (
-              <div className="absolute bottom-full mb-2 right-0 min-w-[200px] rounded-2xl border border-border bg-background py-2 shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-200">
+              <div role="menu" className="absolute bottom-full mb-2 right-0 min-w-[200px] rounded-2xl border border-border bg-background py-2 shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-200">
                 <Link
                   href={profileHref}
                   onClick={() => setMenuOpen(false)}
@@ -229,6 +232,7 @@ export function MobileNav() {
           <Link
             href="/sign-in"
             className={navLinkClass(false)}
+            aria-label="Sign in"
           >
             <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />

--- a/src/components/layout/right-panel.tsx
+++ b/src/components/layout/right-panel.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useQuery } from "@tanstack/react-query";
 import { Avatar } from "@/components/ui/avatar";
 import { FollowButton } from "@/components/profile/follow-button";
 import { AgentFollowButton } from "@/components/profile/agent-follow-button";
-import { PostAiPanel } from "@/components/post/post-ai-panel";
 import { useAiSummary } from "@/components/providers/ai-summary-provider";
 import Link from "next/link";
+
+const PostAiPanel = dynamic(
+  () => import("@/components/post/post-ai-panel").then((m) => m.PostAiPanel),
+  { ssr: false }
+);
 
 interface SuggestedUser {
   id: string;
@@ -40,16 +45,49 @@ function SuggestionSkeleton() {
   );
 }
 
+function SuggestionError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-2 py-2 text-center">
+      <p className="text-sm text-muted">Failed to load suggestions</p>
+      <button
+        onClick={onRetry}
+        className="text-xs font-medium text-cyan transition-colors hover:text-cyan/80"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
 export function RightPanel() {
   const { activeSummary, closeSummary } = useAiSummary();
-  const { data: suggestions, isLoading: loadingSuggestions } = useQuery<SuggestedUser[]>({
+  const {
+    data: suggestions,
+    isLoading: loadingSuggestions,
+    isError: suggestionsError,
+    refetch: refetchSuggestions,
+  } = useQuery<SuggestedUser[]>({
     queryKey: ["suggestions"],
-    queryFn: () => fetch("/api/users/suggestions").then((r) => r.json()),
+    queryFn: async () => {
+      const r = await fetch("/api/users/suggestions");
+      if (!r.ok) throw new Error("Failed to load suggestions");
+      return r.json();
+    },
+    retry: 2,
   });
 
-  const { data: agentSuggestions } = useQuery<SuggestedAgent[]>({
+  const {
+    data: agentSuggestions,
+    isError: agentSuggestionsError,
+    refetch: refetchAgentSuggestions,
+  } = useQuery<SuggestedAgent[]>({
     queryKey: ["agent-suggestions"],
-    queryFn: () => fetch("/api/agents/suggestions").then((r) => r.json()),
+    queryFn: async () => {
+      const r = await fetch("/api/agents/suggestions");
+      if (!r.ok) throw new Error("Failed to load agent suggestions");
+      return r.json();
+    },
+    retry: 2,
   });
 
   return (
@@ -63,6 +101,8 @@ export function RightPanel() {
               <SuggestionSkeleton />
               <SuggestionSkeleton />
             </>
+          ) : suggestionsError ? (
+            <SuggestionError onRetry={() => refetchSuggestions()} />
           ) : suggestions && suggestions.length > 0 ? (
             suggestions.map((user) => (
               <div key={user.id} className="flex items-center gap-3">
@@ -90,7 +130,12 @@ export function RightPanel() {
         </div>
       </div>
 
-      {agentSuggestions && agentSuggestions.length > 0 && (
+      {agentSuggestionsError ? (
+        <div className="rounded-xl border border-border bg-card p-4">
+          <h2 className="mb-4 font-semibold">Agents to follow</h2>
+          <SuggestionError onRetry={() => refetchAgentSuggestions()} />
+        </div>
+      ) : agentSuggestions && agentSuggestions.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
           <h2 className="mb-4 font-semibold">Agents to follow</h2>
           <div className="space-y-4">
@@ -116,7 +161,7 @@ export function RightPanel() {
             ))}
           </div>
         </div>
-      )}
+      ) : null}
 
       <div className="rounded-xl border border-border bg-card p-4">
         <h2 className="mb-4 font-semibold">About Molt</h2>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useSession, signOut } from "next-auth/react";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
-import { ComposeModal } from "@/components/layout/compose-modal";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+const ComposeModal = dynamic(
+  () => import("@/components/layout/compose-modal").then((m) => m.ComposeModal),
+  { ssr: false }
+);
 import { useUnreadCount } from "@/hooks/use-unread-count";
 import { useUnreadMessages } from "@/hooks/use-unread-messages";
 

--- a/src/components/marketplace/star-rating.tsx
+++ b/src/components/marketplace/star-rating.tsx
@@ -29,6 +29,8 @@ export function StarRating({
   return (
     <div
       className="inline-flex items-center gap-0.5"
+      role={interactive ? "radiogroup" : "img"}
+      aria-label={interactive ? "Rating" : `Rating: ${rating} out of ${maxStars} stars`}
       onMouseLeave={() => interactive && setHovered(0)}
     >
       {Array.from({ length: maxStars }, (_, i) => {
@@ -43,6 +45,9 @@ export function StarRating({
             disabled={!interactive}
             onClick={() => interactive && onChange?.(value)}
             onMouseEnter={() => interactive && setHovered(value)}
+            aria-label={`${value} star${value !== 1 ? "s" : ""}`}
+            aria-checked={interactive ? rating === value : undefined}
+            role={interactive ? "radio" : undefined}
             className={cn(
               "transition-colors",
               interactive && "cursor-pointer hover:scale-110",

--- a/src/components/post/post-menu.tsx
+++ b/src/components/post/post-menu.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState, useRef, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { useDeletePost } from "@/hooks/use-delete-post";
-import { EditPostModal } from "@/components/post/edit-post-modal";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+const EditPostModal = dynamic(
+  () => import("@/components/post/edit-post-modal").then((m) => m.EditPostModal),
+  { ssr: false }
+);
 import { useToast } from "@/components/ui/toast";
 
 interface PostMenuProps {

--- a/src/components/post/related-posts-carousel.tsx
+++ b/src/components/post/related-posts-carousel.tsx
@@ -40,9 +40,10 @@ export function RelatedPostsCarousel({ postId, enabled }: RelatedPostsCarouselPr
       <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted">
         Related Posts
       </p>
-      <div className="relative">
+      <div className="relative" role="region" aria-label="Related posts carousel">
         <button
           onClick={() => scroll("left")}
+          aria-label="Scroll left"
           className="absolute -left-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full border border-border bg-background/90 p-1.5 text-muted shadow-sm backdrop-blur-sm transition-colors hover:text-foreground sm:flex"
         >
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -60,6 +61,7 @@ export function RelatedPostsCarousel({ postId, enabled }: RelatedPostsCarouselPr
         </div>
         <button
           onClick={() => scroll("right")}
+          aria-label="Scroll right"
           className="absolute -right-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full border border-border bg-background/90 p-1.5 text-muted shadow-sm backdrop-blur-sm transition-colors hover:text-foreground sm:flex"
         >
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/hooks/use-agent-follow.ts
+++ b/src/hooks/use-agent-follow.ts
@@ -13,11 +13,12 @@ export function useAgentFollow(slug: string) {
       if (!res.ok) throw new Error("Failed to toggle agent follow");
       return res.json() as Promise<{ following: boolean }>;
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["agent-profile", slug] });
       queryClient.invalidateQueries({ queryKey: ["agent-suggestions"] });
-      queryClient.invalidateQueries({ queryKey: ["marketplace"] });
-      queryClient.invalidateQueries({ queryKey: ["feed", "following"], refetchType: "none" });
+      if (data.following) {
+        queryClient.invalidateQueries({ queryKey: ["feed", "following"], refetchType: "none" });
+      }
     },
   });
 }

--- a/src/hooks/use-create-post.ts
+++ b/src/hooks/use-create-post.ts
@@ -19,7 +19,10 @@ export function useCreatePost() {
       return res.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["feed"] });
+      queryClient.invalidateQueries({ queryKey: ["feed", "following"] });
+      queryClient.invalidateQueries({ queryKey: ["feed", "foryou"] });
+      queryClient.invalidateQueries({ queryKey: ["feed", "explore"], refetchType: "none" });
+      queryClient.invalidateQueries({ queryKey: ["new-post-count"] });
     },
   });
 }

--- a/src/hooks/use-follow.ts
+++ b/src/hooks/use-follow.ts
@@ -13,10 +13,12 @@ export function useFollow(username: string) {
       if (!res.ok) throw new Error("Failed to toggle follow");
       return res.json() as Promise<{ following: boolean }>;
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["profile", username] });
       queryClient.invalidateQueries({ queryKey: ["suggestions"] });
-      queryClient.invalidateQueries({ queryKey: ["feed", "following"], refetchType: "none" });
+      if (data.following) {
+        queryClient.invalidateQueries({ queryKey: ["feed", "following"], refetchType: "none" });
+      }
     },
   });
 }

--- a/src/hooks/use-send-message.ts
+++ b/src/hooks/use-send-message.ts
@@ -1,9 +1,17 @@
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient, InfiniteData } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import type { MessageData } from "@/hooks/use-messages";
+
+interface MessagesResponse {
+  messages: MessageData[];
+  nextCursor: string | null;
+}
 
 export function useSendMessage(conversationId: string) {
   const queryClient = useQueryClient();
+  const { data: session } = useSession();
 
   return useMutation({
     mutationFn: async (content: string) => {
@@ -15,7 +23,53 @@ export function useSendMessage(conversationId: string) {
       if (!res.ok) throw new Error("Failed to send message");
       return res.json();
     },
-    onSuccess: () => {
+    onMutate: async (content) => {
+      await queryClient.cancelQueries({ queryKey: ["messages", conversationId] });
+
+      const previousMessages = queryClient.getQueryData<InfiniteData<MessagesResponse>>(
+        ["messages", conversationId]
+      );
+
+      const optimisticMessage: MessageData = {
+        id: `optimistic-${Date.now()}`,
+        content,
+        createdAt: new Date().toISOString(),
+        conversationId,
+        sender: session?.user
+          ? {
+              type: "user" as const,
+              id: session.user.id!,
+              name: session.user.name ?? null,
+              username: session.user.username ?? null,
+              image: session.user.image ?? null,
+            }
+          : null,
+      };
+
+      queryClient.setQueryData<InfiniteData<MessagesResponse>>(
+        ["messages", conversationId],
+        (old) => {
+          if (!old) return old;
+          const newPages = [...old.pages];
+          newPages[0] = {
+            ...newPages[0],
+            messages: [optimisticMessage, ...newPages[0].messages],
+          };
+          return { ...old, pages: newPages };
+        }
+      );
+
+      return { previousMessages };
+    },
+    onError: (_err, _content, context) => {
+      if (context?.previousMessages) {
+        queryClient.setQueryData(
+          ["messages", conversationId],
+          context.previousMessages
+        );
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["messages", conversationId] });
       queryClient.invalidateQueries({ queryKey: ["conversations"] });
     },


### PR DESCRIPTION
- Narrow query invalidation on post creation (target specific feed types
  instead of all feeds) and follow mutations (skip feed invalidation on
  unfollow, remove unnecessary marketplace invalidation)
- Add Cache-Control headers to 6 public GET endpoints (marketplace,
  proposals, replies, related posts, user posts, agent feed)
- Add optimistic insertion for chat messages so they appear instantly
  before server confirmation, with rollback on error
- Add loading.tsx skeletons to 11 routes (messages, conversation detail,
  agent profile, marketplace, governance, dashboard, admin overview and
  5 admin sub-pages)
- Add error state with retry button to right panel suggestion queries
  for both user and agent suggestions, with retry: 2 config
- Add ARIA roles/labels to mobile nav (aria-label, aria-current,
  aria-expanded, role=menu), star rating (role=radiogroup/img,
  aria-label per star), and carousel buttons (aria-label, role=region)
- Add generateMetadata via layout files for marketplace, governance,
  and search pages (home inherits from root layout)
- Lazy-load heavy components: PostAiPanel (react-markdown) via
  next/dynamic in post detail and right panel, ComposeModal in sidebar
  and mobile button, EditPostModal, RatingModal, CreateProposalModal

https://claude.ai/code/session_01XZ7MmHuh8wN62qyXG1vp8a