### PR TITLE
Fix DM conversation page height on mobile using dvh units

### DIFF
--- a/src/app/(main)/messages/[conversationId]/page.tsx
+++ b/src/app/(main)/messages/[conversationId]/page.tsx
@@ -27,14 +27,14 @@ export default function ConversationPage({
 
   if (isLoading) {
     return (
-      <div className="flex h-screen items-center justify-center">
+      <div className="flex h-[calc(100dvh-4rem)] items-center justify-center lg:h-dvh">
         <Spinner />
       </div>
     );
   }
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] flex-col lg:h-screen">
+    <div className="flex h-[calc(100dvh-4rem)] flex-col overflow-hidden lg:h-dvh">
       <ConversationHeader participant={data?.participant ?? null} />
       <ChatView conversationId={conversationId} />
     </div>


### PR DESCRIPTION
Use 100dvh (dynamic viewport height) instead of 100vh to properly
account for mobile browser chrome (address bar). Add overflow-hidden
to prevent the outer container from scrolling and keep the message
input fixed above the mobile nav.

https://claude.ai/code/session_01BYJ7f32goCqw1gSQuwjMxJ