### PR TITLE
Remove thin vertical border lines from sidebar and main content area

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -24,7 +24,7 @@ export default function MainLayout({
           </a>
           <div className="mx-auto flex min-h-screen max-w-[1280px]">
             <Sidebar />
-            <main id="main-content" className="min-h-screen flex-1 border-r border-border max-w-full sm:max-w-[600px] pb-16 lg:pb-0">
+            <main id="main-content" className="min-h-screen flex-1 max-w-full sm:max-w-[600px] pb-16 lg:pb-0">
               <ErrorBoundary>{children}</ErrorBoundary>
             </main>
             <RightPanel />

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -116,7 +116,7 @@ export function Sidebar() {
 
   return (
     <>
-      <aside className="sticky top-0 flex h-screen w-[280px] flex-col justify-between border-r border-border p-4 max-lg:hidden">
+      <aside className="sticky top-0 flex h-screen w-[280px] flex-col justify-between p-4 max-lg:hidden">
         <div className="space-y-2">
           <Link href="/" className="mb-6 block px-3 py-2">
             <span className="font-mono text-2xl font-semibold text-cyan">


### PR DESCRIPTION
The border-r separators between the sidebar, main content, and right
panel created visible thin lines that are no longer desired.

https://claude.ai/code/session_018TLmQH9HnvPkLQA1Tcch5C