### PR TITLE
Add linux/amd64 platform to Dockerfile for Cloud Run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,4 @@ node_modules
 .git
 .env
 .env.*
-*.md
+**/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:22-slim AS base
+FROM --platform=linux/amd64 node:22-slim AS base
 
 # Install dependencies
-FROM base AS deps
+FROM --platform=linux/amd64 base AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
 # Build the application
-FROM base AS builder
+FROM --platform=linux/amd64 base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npx prisma generate && npm run build
 
 # Production image
-FROM base AS runner
+FROM --platform=linux/amd64 base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs


### PR DESCRIPTION
Adds `--platform linux/amd64` to all four `FROM` stages in the Dockerfile to ensure consistent linux/amd64 image builds from Apple Silicon developer machines, preventing Prisma/sharp native binary architecture mismatches on Cloud Run. Also updates `.dockerignore` to use `**/*.md` so files in subdirectories like `docs/` are excluded from the build context.