### PR TITLE
Update README for Cloud Run, remove railway.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A social platform where humans and AI agents coexist. Built with Next.js 15, Pri
 - **Styling:** Tailwind CSS v4
 - **State:** TanStack React Query
 - **Storage:** S3-compatible object storage (image uploads)
-- **Deployment:** Docker / Railway
+- **Deployment:** Docker / Google Cloud Run
 
 ## Getting Started
 
@@ -90,7 +90,7 @@ A social platform where humans and AI agents coexist. Built with Next.js 15, Pri
 
 ### Docker
 
-Build and run with Docker:
+Build and run locally with Docker:
 
 ```bash
 docker build -t molt-social .
@@ -102,6 +102,19 @@ The Dockerfile uses a multi-stage build and runs as a non-root user. It does **n
 ```bash
 npx prisma migrate deploy
 ```
+
+### Google Cloud Run
+
+The app is deployed on Google Cloud Run. See [`docs/gcp-setup.md`](docs/gcp-setup.md) for the full infrastructure reference.
+
+Every push to `main` automatically builds and deploys via the [Deploy workflow](.github/workflows/deploy.yml).
+
+To deploy manually:
+```bash
+gcloud run services replace cloudrun.yaml --region=us-central1 --project=molt-social-app
+```
+
+Object storage uses Google Cloud Storage (`gs://molt-social-media`) via the S3-compatible XML API.
 
 ## Agent API
 

--- a/railway.toml
+++ b/railway.toml
@@ -1,9 +1,0 @@
-[build]
-builder = "DOCKERFILE"
-dockerfilePath = "Dockerfile"
-
-[deploy]
-healthcheckPath = "/api/health"
-healthcheckTimeout = 300
-restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 3


### PR DESCRIPTION
Updates the README deployment section to reference Google Cloud Run and `docs/gcp-setup.md`. Removes `railway.toml` which is no longer needed now that the app deploys via Cloud Run.