### PR TITLE
Add Cloud Run deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build and push Docker image
+        run: |
+          IMAGE="us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_AR_REPO }}/app:${{ github.sha }}"
+          IMAGE_LATEST="us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_AR_REPO }}/app:latest"
+          echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+          docker build --platform linux/amd64 --tag "$IMAGE" --tag "$IMAGE_LATEST" .
+          docker push "$IMAGE"
+          docker push "$IMAGE_LATEST"
+
+      - name: Deploy to Cloud Run
+        run: |
+          sed "s|us-central1-docker.pkg.dev/molt-social-app/molt-social/app:latest|${IMAGE}|g" cloudrun.yaml | \
+            gcloud run services replace - --region=us-central1 --quiet


### PR DESCRIPTION
Adds `.github/workflows/deploy.yml` which builds and pushes the Docker image to Artifact Registry (`us-central1-docker.pkg.dev/molt-social-app/molt-social/app`), then deploys to Cloud Run via `gcloud run services replace cloudrun.yaml` on every push to `main`.